### PR TITLE
feat: 서버 안정성 및 동시성 제어 개선 (연결 제한, Graceful Shutdown, Token Bucket)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::TcpStream,
     sync::broadcast,
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{
     metrics::Metrics,
@@ -13,6 +13,9 @@ use crate::{
     room::Room,
     vote::VoteBoard,
 };
+
+const TOKEN_CAPACITY: f64 = 10.0;
+const TOKEN_RATE: f64 = 10.0;
 
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -56,6 +59,8 @@ pub async fn handle_client(
     });
 
     let mut current_vote: Option<usize> = None;
+    let mut tokens: f64 = TOKEN_CAPACITY;
+    let mut last_refill = Instant::now();
 
     // read task (현재 task): 소켓 수신 → 처리
     loop {
@@ -72,6 +77,16 @@ pub async fn handle_client(
                             Ok(m) => m,
                             Err(_) => continue,
                         };
+
+                        // 클라이언트별 rate limiting: 토큰 버킷 (10 token/s, burst 10)
+                        let elapsed = last_refill.elapsed().as_secs_f64();
+                        last_refill = Instant::now();
+                        tokens = (tokens + elapsed * TOKEN_RATE).min(TOKEN_CAPACITY);
+                        if tokens < 1.0 {
+                            warn!(id, "rate limit 초과 — 메시지 드롭");
+                            continue;
+                        }
+                        tokens -= 1.0;
 
                         match msg {
                             ClientMsg::Chat { text, client_ts } => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use tracing::{info, warn};
 use crate::{
     client::handle_client,
     metrics::Metrics,
-    protocol::ServerMsg,
+    protocol::{BroadcastEvent, ServerMsg},
     room::Room,
     vote::VoteBoard,
 };
@@ -22,38 +22,49 @@ pub async fn run(addr: &str, room: Arc<Room>, vote: Arc<VoteBoard>, metrics: Arc
     info!("서버 시작: {addr}");
 
     loop {
-        match listener.accept().await {
-            Ok((stream, peer)) => {
-                // 연결 수 상한 확인: 초과 시 오류 응답 후 즉시 소켓 닫기
-                if CONN_COUNT.load(Ordering::Relaxed) >= MAX_CONNECTIONS {
-                    warn!(%peer, "최대 연결 수 초과 — 접속 거절");
-                    tokio::spawn(async move {
-                        let (_, mut writer) = stream.into_split();
-                        let msg = ServerMsg::Error { msg: "서버가 가득 찼습니다 (최대 500인)".into() };
-                        if let Ok(mut line) = serde_json::to_string(&msg) {
-                            line.push('\n');
-                            let _ = writer.write_all(line.as_bytes()).await;
+        tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, peer)) => {
+                        // 연결 수 상한 확인: 초과 시 오류 응답 후 즉시 소켓 닫기
+                        if CONN_COUNT.load(Ordering::Relaxed) >= MAX_CONNECTIONS {
+                            warn!(%peer, "최대 연결 수 초과 — 접속 거절");
+                            tokio::spawn(async move {
+                                let (_, mut writer) = stream.into_split();
+                                let msg = ServerMsg::Error { msg: "서버가 가득 찼습니다 (최대 500인)".into() };
+                                if let Ok(mut line) = serde_json::to_string(&msg) {
+                                    line.push('\n');
+                                    let _ = writer.write_all(line.as_bytes()).await;
+                                }
+                            });
+                            continue;
                         }
-                    });
-                    continue;
-                }
 
-                CONN_COUNT.fetch_add(1, Ordering::Relaxed);
-                let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-                let room = room.clone();
-                let vote = vote.clone();
-                let metrics = metrics.clone();
-                info!(id, %peer, "클라이언트 접속 (현재 {}명)", CONN_COUNT.load(Ordering::Relaxed));
-                tokio::spawn(async move {
-                    if let Err(e) = handle_client(id, stream, room, vote, metrics).await {
-                        warn!(id, "클라이언트 오류: {e}");
+                        CONN_COUNT.fetch_add(1, Ordering::Relaxed);
+                        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+                        let room = room.clone();
+                        let vote = vote.clone();
+                        let metrics = metrics.clone();
+                        info!(id, %peer, "클라이언트 접속 (현재 {}명)", CONN_COUNT.load(Ordering::Relaxed));
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_client(id, stream, room, vote, metrics).await {
+                                warn!(id, "클라이언트 오류: {e}");
+                            }
+                            CONN_COUNT.fetch_sub(1, Ordering::Relaxed);
+                        });
                     }
-                    CONN_COUNT.fetch_sub(1, Ordering::Relaxed);
-                });
+                    Err(e) => {
+                        warn!("accept 실패: {e}");
+                    }
+                }
             }
-            Err(e) => {
-                warn!("accept 실패: {e}");
+            _ = tokio::signal::ctrl_c() => {
+                info!("SIGINT 수신 — graceful shutdown 시작");
+                let _ = room.tx.send(BroadcastEvent::Shutdown);
+                break;
             }
         }
     }
+
+    Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,16 +1,21 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tracing::{info, warn};
 
 use crate::{
     client::handle_client,
     metrics::Metrics,
+    protocol::ServerMsg,
     room::Room,
     vote::VoteBoard,
 };
 
+pub const MAX_CONNECTIONS: usize = 500;
+
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+pub static CONN_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 pub async fn run(addr: &str, room: Arc<Room>, vote: Arc<VoteBoard>, metrics: Arc<Metrics>) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr).await?;
@@ -19,15 +24,31 @@ pub async fn run(addr: &str, room: Arc<Room>, vote: Arc<VoteBoard>, metrics: Arc
     loop {
         match listener.accept().await {
             Ok((stream, peer)) => {
+                // 연결 수 상한 확인: 초과 시 오류 응답 후 즉시 소켓 닫기
+                if CONN_COUNT.load(Ordering::Relaxed) >= MAX_CONNECTIONS {
+                    warn!(%peer, "최대 연결 수 초과 — 접속 거절");
+                    tokio::spawn(async move {
+                        let (_, mut writer) = stream.into_split();
+                        let msg = ServerMsg::Error { msg: "서버가 가득 찼습니다 (최대 500인)".into() };
+                        if let Ok(mut line) = serde_json::to_string(&msg) {
+                            line.push('\n');
+                            let _ = writer.write_all(line.as_bytes()).await;
+                        }
+                    });
+                    continue;
+                }
+
+                CONN_COUNT.fetch_add(1, Ordering::Relaxed);
                 let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
                 let room = room.clone();
                 let vote = vote.clone();
                 let metrics = metrics.clone();
-                info!(id, %peer, "클라이언트 접속");
+                info!(id, %peer, "클라이언트 접속 (현재 {}명)", CONN_COUNT.load(Ordering::Relaxed));
                 tokio::spawn(async move {
                     if let Err(e) = handle_client(id, stream, room, vote, metrics).await {
                         warn!(id, "클라이언트 오류: {e}");
                     }
+                    CONN_COUNT.fetch_sub(1, Ordering::Relaxed);
                 });
             }
             Err(e) => {


### PR DESCRIPTION
## 변경 사항 (Changes)

### 1. 최대 연결 수 제한 (Fixes #2)
- `CONN_COUNT` (`AtomicUsize`)를 도입하여 스레드 안전하게 현재 활성화된 연결 수를 추적합니다.
- `accept` 단계에서 설정된 `MAX_CONNECTIONS` (500명) 초과 여부를 검증합니다.
- 제한 인원을 초과한 연결 시도는 클라이언트에게 `ServerMsg::Error`를 전송한 후 소켓을 즉시 닫아 리소스를 보호합니다.
- 정상적으로 수락된 클라이언트는 `handle_client` 라이프사이클 종료 시점에 안전하게 `CONN_COUNT`를 감소시킵니다.

### 2. Graceful Shutdown 처리 (Fixes #3)
- `tokio::signal::ctrl_c()`를 활용하여 `SIGINT` (Ctrl+C) 시그널을 비동기적으로 감지하고 메인 `accept` 루프를 안전하게 종료합니다.
- 종료 이벤트 발생 시 `room.tx`를 통해 `BroadcastEvent::Shutdown` 메시지를 전파합니다.
- 이를 통해 생성되어 있던 모든 `write_task`들이 강제 종료되지 않고 클린하게 마무리될 수 있도록 처리했습니다.

### 3. Rate Limiter 알고리즘 교체 (Fixes #4)
- 기존 Fixed Window 방식에서 발생하던 윈도우 경계선에서의 트래픽 버스트(Burst) 문제를 해결하기 위해 **Token Bucket** 알고리즘으로 교체했습니다.
- 버킷의 최대 용량 및 충전율을 `10회/초`로 설정하여 보다 일관된 메시지 처리율을 보장합니다.
- 허용량을 초과하여 인입되는 메시지는 서버 단에서 즉시 드롭(Drop) 처리하여 부하를 방지합니다.