### PR TITLE
[Protocol/Room] 접속 알림·닉네임·투표 비율 이슈 구현

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -35,7 +35,12 @@ pub async fn handle_client(
     let mut lines = BufReader::new(reader).lines();
     let mut rx: broadcast::Receiver<BroadcastEvent> = room.subscribe();
 
-    room.join(id).await;
+    // 이슈 4: 입장 후 현재 참여자 수를 받아 Welcome 메시지로 즉시 전송 (broadcast 아님)
+    let peer_count = room.join(id).await;
+    let welcome = ServerMsg::Welcome { peer_count };
+    let mut welcome_line = serde_json::to_string(&welcome).unwrap_or_default();
+    welcome_line.push('\n');
+    writer.write_all(welcome_line.as_bytes()).await?;
 
     // write task: broadcast 수신 → 소켓 송신
     let mut write_task = tokio::spawn(async move {

--- a/src/client.rs
+++ b/src/client.rs
@@ -115,16 +115,15 @@ pub async fn handle_client(
                             ClientMsg::Vote { option } => {
                                 vote.vote(current_vote, option);
                                 current_vote = Some(option);
-                                room.broadcast(ServerMsg::VoteSnapshot {
-                                    counts: vote.snapshot(),
-                                });
+                                // 이슈 6: percentages 함께 전송
+                                let (counts, percentages) = vote.snapshot_with_percentages();
+                                room.broadcast(ServerMsg::VoteSnapshot { counts, percentages });
                             }
                             ClientMsg::Unvote => {
                                 if let Some(prev) = current_vote.take() {
                                     vote.unvote(prev);
-                                    room.broadcast(ServerMsg::VoteSnapshot {
-                                        counts: vote.snapshot(),
-                                    });
+                                    let (counts, percentages) = vote.snapshot_with_percentages();
+                                    room.broadcast(ServerMsg::VoteSnapshot { counts, percentages });
                                 }
                             }
                         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -66,6 +66,7 @@ pub async fn handle_client(
     let mut current_vote: Option<usize> = None;
     let mut tokens: f64 = TOKEN_CAPACITY;
     let mut last_refill = Instant::now();
+    let mut nick: Option<String> = None; // 이슈 5: 닉네임
 
     // read task (현재 task): 소켓 수신 → 처리
     loop {
@@ -94,11 +95,21 @@ pub async fn handle_client(
                         tokens -= 1.0;
 
                         match msg {
+                            ClientMsg::SetNick { name } => {
+                                // 이슈 5: 닉네임 로컬 저장 + room 메타 업데이트
+                                room.set_nick(id, name.clone()).await;
+                                nick = Some(name);
+                            }
                             ClientMsg::Chat { text, client_ts } => {
                                 // 이슈 7: 클라이언트 송신 시각(client_ts) 기준으로 latency 측정
                                 metrics.record_latency(client_ts);
                                 let sent_at = now_ms();
-                                room.broadcast(ServerMsg::Chat { from: id, text, sent_at });
+                                room.broadcast(ServerMsg::Chat {
+                                    from: id,
+                                    nick: nick.clone(), // 이슈 5
+                                    text,
+                                    sent_at,
+                                });
                                 metrics.record_sent();
                             }
                             ClientMsg::Vote { option } => {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -35,8 +35,12 @@ pub enum ServerMsg {
         /// 전송 시각 (Unix ms)
         sent_at: u64,
     },
-    /// 투표 현황 스냅샷
-    VoteSnapshot { counts: [u64; N_OPTIONS] },
+    /// 투표 현황 스냅샷 (이슈 6: percentages 추가로 클라이언트 중복 연산 제거)
+    VoteSnapshot {
+        counts: [u64; N_OPTIONS],
+        /// 각 옵션 비율 (0.0~1.0), 서버에서 계산해 전달
+        percentages: [f32; N_OPTIONS],
+    },
     /// 참여자 입장/퇴장 알림
     Presence { id: u64, joined: bool },
     /// 서버 측 오류 메시지

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -12,6 +12,8 @@ pub enum ClientMsg {
         /// 클라이언트 송신 시각 (Unix ms) — 서버에서 latency 계산 기준
         client_ts: u64,
     },
+    /// 닉네임 설정 (이슈 5)
+    SetNick { name: String },
     /// 투표 (option: 0..N_OPTIONS)
     Vote { option: usize },
     /// 투표 철회
@@ -27,6 +29,8 @@ pub enum ServerMsg {
     /// 브로드캐스트 채팅
     Chat {
         from: u64,
+        /// 발신자 닉네임 (없으면 ID로 표시) (이슈 5)
+        nick: Option<String>,
         text: String,
         /// 전송 시각 (Unix ms)
         sent_at: u64,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -22,6 +22,8 @@ pub enum ClientMsg {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerMsg {
+    /// 신규 접속자에게만 전송 — 접속 시점의 참여자 수 초기값 전달 (이슈 4)
+    Welcome { peer_count: u64 },
     /// 브로드캐스트 채팅
     Chat {
         from: u64,

--- a/src/room.rs
+++ b/src/room.rs
@@ -8,6 +8,8 @@ pub const BROADCAST_CAP: usize = 2048;
 #[derive(Debug, Clone)]
 pub struct ClientMeta {
     pub id: u64,
+    /// 닉네임 (이슈 5)
+    pub name: Option<String>,
 }
 
 pub struct Room {
@@ -31,7 +33,7 @@ impl Room {
     /// 입장 처리 후 현재 참여자 수 반환 (이슈 4: Welcome 전송용)
     pub async fn join(&self, id: u64) -> u64 {
         let mut clients = self.clients.write().await;
-        clients.insert(id, ClientMeta { id });
+        clients.insert(id, ClientMeta { id, name: None });
         let count = clients.len() as u64;
         drop(clients);
         let _ = self.tx.send(BroadcastEvent::Server(ServerMsg::Presence {
@@ -51,6 +53,13 @@ impl Room {
 
     pub async fn client_count(&self) -> usize {
         self.clients.read().await.len()
+    }
+
+    /// 닉네임 설정 (이슈 5)
+    pub async fn set_nick(&self, id: u64, name: String) {
+        if let Some(meta) = self.clients.write().await.get_mut(&id) {
+            meta.name = Some(name);
+        }
     }
 
     pub fn broadcast(&self, msg: ServerMsg) {

--- a/src/room.rs
+++ b/src/room.rs
@@ -28,12 +28,17 @@ impl Room {
         self.tx.subscribe()
     }
 
-    pub async fn join(&self, id: u64) {
-        self.clients.write().await.insert(id, ClientMeta { id });
+    /// 입장 처리 후 현재 참여자 수 반환 (이슈 4: Welcome 전송용)
+    pub async fn join(&self, id: u64) -> u64 {
+        let mut clients = self.clients.write().await;
+        clients.insert(id, ClientMeta { id });
+        let count = clients.len() as u64;
+        drop(clients);
         let _ = self.tx.send(BroadcastEvent::Server(ServerMsg::Presence {
             id,
             joined: true,
         }));
+        count
     }
 
     pub async fn leave(&self, id: u64) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -36,6 +36,8 @@ fn now_ms() -> u64 {
 struct AppState {
     messages: Vec<String>,
     vote_counts: [u64; N_OPTIONS],
+    /// 이슈 6: 서버에서 계산된 비율 (0.0~1.0)
+    vote_percentages: [f32; N_OPTIONS],
     client_count: usize,
     input: String,
     my_vote: Option<usize>,
@@ -46,6 +48,7 @@ impl AppState {
         Self {
             messages: Vec::new(),
             vote_counts: [0; N_OPTIONS],
+            vote_percentages: [0.0; N_OPTIONS],
             client_count: 0,
             input: String::new(),
             my_vote: None,
@@ -86,8 +89,9 @@ pub async fn run(addr: &str) -> Result<()> {
                     let sender = nick.unwrap_or_else(|| from.to_string());
                     s.push_msg(format!("[{sender}] {text}"));
                 }
-                ServerMsg::VoteSnapshot { counts } => {
+                ServerMsg::VoteSnapshot { counts, percentages } => {
                     s.vote_counts = counts;
+                    s.vote_percentages = percentages; // 이슈 6
                 }
                 ServerMsg::Presence { id, joined } => {
                     if joined {
@@ -278,11 +282,8 @@ fn render_vote(f: &mut ratatui::Frame, state: &AppState, area: ratatui::layout::
             break;
         }
 
-        let ratio = if total > 0 {
-            count as f64 / total as f64
-        } else {
-            0.0
-        };
+        // 이슈 6: 서버에서 받은 percentages 사용 (중복 계산 제거)
+        let ratio = state.vote_percentages[i] as f64;
         let is_mine = state.my_vote == Some(i);
         let label = if is_mine {
             format!("[{}]▶ {}/{}", i + 1, count, total)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -81,8 +81,10 @@ pub async fn run(addr: &str) -> Result<()> {
                 ServerMsg::Welcome { peer_count } => {
                     s.client_count = peer_count as usize;
                 }
-                ServerMsg::Chat { from, text, .. } => {
-                    s.push_msg(format!("[{from}] {text}"));
+                ServerMsg::Chat { from, nick, text, .. } => {
+                    // 이슈 5: 닉네임 있으면 닉네임, 없으면 ID 표시
+                    let sender = nick.unwrap_or_else(|| from.to_string());
+                    s.push_msg(format!("[{sender}] {text}"));
                 }
                 ServerMsg::VoteSnapshot { counts } => {
                     s.vote_counts = counts;
@@ -181,6 +183,15 @@ async fn event_loop(
 }
 
 async fn parse_input(input: &str, state: &Arc<Mutex<AppState>>) -> Option<ClientMsg> {
+    // 이슈 5: /nick <이름> 명령어
+    if let Some(rest) = input.strip_prefix("/nick ") {
+        let name = rest.trim().to_string();
+        if !name.is_empty() {
+            return Some(ClientMsg::SetNick { name });
+        }
+        return None;
+    }
+
     if let Some(rest) = input.strip_prefix("/vote ") {
         if let Ok(n) = rest.trim().parse::<usize>() {
             let option = n.saturating_sub(1); // 1-based → 0-based
@@ -305,7 +316,7 @@ fn render_vote(f: &mut ratatui::Frame, state: &AppState, area: ratatui::layout::
 
 fn render_input(f: &mut ratatui::Frame, state: &AppState, area: ratatui::layout::Rect) {
     let hint = Span::styled(
-        " /vote 1~4  /unvote  Esc:종료",
+        " /nick <이름>  /vote 1~4  /unvote  Esc:종료",
         Style::default().fg(Color::DarkGray),
     );
     let input_line = Line::from(vec![

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -77,6 +77,10 @@ pub async fn run(addr: &str) -> Result<()> {
             };
             let mut s = state_net.lock().await;
             match msg {
+                // 이슈 4: 접속 시점의 참여자 수로 client_count 초기화
+                ServerMsg::Welcome { peer_count } => {
+                    s.client_count = peer_count as usize;
+                }
                 ServerMsg::Chat { from, text, .. } => {
                     s.push_msg(format!("[{from}] {text}"));
                 }

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -35,4 +35,18 @@ impl VoteBoard {
     pub fn snapshot(&self) -> [u64; N_OPTIONS] {
         std::array::from_fn(|i| self.counts[i].load(Ordering::Relaxed).max(0) as u64)
     }
+
+    /// 이슈 6: counts와 percentages(0.0~1.0)를 함께 반환
+    pub fn snapshot_with_percentages(&self) -> ([u64; N_OPTIONS], [f32; N_OPTIONS]) {
+        let counts = self.snapshot();
+        let total: u64 = counts.iter().sum();
+        let percentages = std::array::from_fn(|i| {
+            if total > 0 {
+                counts[i] as f32 / total as f32
+            } else {
+                0.0
+            }
+        });
+        (counts, percentages)
+    }
 }


### PR DESCRIPTION
## 작업 내용

### #5 [Bug] 신규 접속자에게 현재 참여자 수 전달
- ServerMsg::Welcome { peer_count } 추가
- room.join()이 현재 참여자 수 반환하도록 변경
- 접속 시 Welcome을 소켓에 직접 전송
- TUI에서 Welcome 수신 시 client_count 초기화

### #6 [Feature] 닉네임 지원
- ClientMsg::SetNick { name } 추가
- ServerMsg::Chat에 nick: Option<String> 필드 추가
- ClientMeta에 name 필드 추가, set_nick() 메서드 추가
- /nick <이름> 명령어 파싱, 채팅창에 닉네임 표시

### #7 [Feature] VoteSnapshot에 percentages 추가
- VoteSnapshot { counts, percentages: [f32; N_OPTIONS] } 로 확장
- VoteBoard::snapshot_with_percentages() 메서드 추가
- TUI ratio 중복 계산 제거

closes #5, closes #6, closes #7