### PR TITLE
[Bot&test] 봇 혼합모드 및 통합 테스트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ target
 
 # Claude Code
 .claude/
-
+.kiro/
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,8 @@ dependencies = [
  "bytes",
  "clap",
  "crossterm",
- "rand",
+ "proptest",
+ "rand 0.8.6",
  "ratatui",
  "serde",
  "serde_json",
@@ -91,6 +92,27 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -227,7 +249,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -299,6 +321,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +362,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,16 +398,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -400,6 +483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +499,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -432,7 +527,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -478,6 +573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -537,6 +641,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +658,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -555,14 +694,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -572,7 +733,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -581,7 +752,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -660,8 +849,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -669,6 +871,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -681,6 +895,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -842,6 +1062,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,10 +1245,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi"
@@ -1133,6 +1439,100 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ name = "Rust_Projects"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+name = "rust_projects"
+path = "src/lib.rs"
+
+[[bin]]
+name = "Rust_Projects"
+path = "src/main.rs"
+
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
@@ -17,3 +25,6 @@ clap = { version = "4", features = ["derive"] }
 rand = "0.8"
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
+
+[dev-dependencies]
+proptest = "1"

--- a/src/bot/fickle.rs
+++ b/src/bot/fickle.rs
@@ -1,25 +1,55 @@
-use tokio::io::BufWriter;
+use tokio::io::{AsyncBufReadExt, BufReader, BufWriter};
 use tokio::time::{sleep, Duration};
 use anyhow::Result;
 use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
-use crate::protocol::{ClientMsg, N_OPTIONS};
-use super::{connect, send_msg};
+use crate::protocol::{ClientMsg, ServerMsg, N_OPTIONS};
+use super::{connect, send_msg, FickleResult};
 
-pub async fn run(id: u64, vote_count: usize) -> Result<()> {
+pub async fn run(id: u64, vote_count: usize) -> Result<FickleResult> {
     let stream = connect().await?;
-    let (_reader, writer) = stream.into_split();
+    let (reader, writer) = stream.into_split();
     let mut writer = BufWriter::new(writer);
     let mut rng = StdRng::from_entropy();
 
+    let last_snapshot: Arc<Mutex<Option<[u64; N_OPTIONS]>>> = Arc::new(Mutex::new(None));
+    let snapshot_clone = last_snapshot.clone();
+
+    // 수신 태스크: VoteSnapshot 저장
+    let recv_task = tokio::spawn(async move {
+        let buf_reader = BufReader::new(reader);
+        let mut lines = buf_reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Ok(msg) = serde_json::from_str::<ServerMsg>(&line) {
+                if let ServerMsg::VoteSnapshot { counts, .. } = msg {
+                    *snapshot_clone.lock().await = Some(counts);
+                }
+            }
+        }
+    });
+
+    // 투표 루프: 마지막 투표 옵션 추적
+    let mut last_vote: Option<usize> = None;
     for _ in 0..vote_count {
         let option = rng.gen_range(0..N_OPTIONS);
         send_msg(&mut writer, &ClientMsg::Vote { option }).await?;
+        last_vote = Some(option);
         // 10ms 간격으로 투표 변경
         sleep(Duration::from_millis(10)).await;
     }
 
+    // 마지막 VoteSnapshot 수신 대기
+    sleep(Duration::from_millis(200)).await;
+    recv_task.abort();
+
+    let snapshot = last_snapshot.lock().await.clone();
+
     let _ = id; // id는 로그용 예약
-    Ok(())
+    Ok(FickleResult {
+        last_vote,
+        last_snapshot: snapshot,
+    })
 }

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -5,14 +5,229 @@ pub mod quitter;
 pub mod spammer;
 
 use anyhow::Result;
+use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 use tokio::net::TcpStream;
 use tracing::info;
 
 use crate::protocol::ClientMsg;
 
 pub const SERVER_ADDR: &str = "127.0.0.1:8080";
+pub const BOT_RECV_TIMEOUT_SECS: u64 = 30;
+
+// ── Scenario Report: RttCounter ─────────────────────────────────────
+
+/// Lock-free RTT 누적 카운터 (AtomicU64 기반)
+pub struct RttCounter {
+    pub sum_ms: AtomicU64,
+    pub count: AtomicU64,
+}
+
+impl RttCounter {
+    /// 새 RttCounter를 Arc로 감싸서 생성
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sum_ms: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        })
+    }
+
+    /// RTT 값(밀리초)을 누적 기록
+    pub fn record(&self, rtt_ms: u64) {
+        self.sum_ms.fetch_add(rtt_ms, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// 평균 RTT 계산. 기록이 없으면 None 반환
+    pub fn average(&self) -> Option<u64> {
+        let c = self.count.load(Ordering::Relaxed);
+        if c == 0 {
+            None
+        } else {
+            Some(self.sum_ms.load(Ordering::Relaxed) / c)
+        }
+    }
+}
+
+// ── Scenario Report: ScenarioReport 구조체 ──────────────────────────
+
+/// 시나리오 실행 결과 요약 리포트
+#[derive(Debug)]
+pub struct ScenarioReport {
+    pub mode: String,
+    pub total_bots: usize,
+    pub success_count: usize,
+    pub failure_count: usize,
+    pub elapsed_secs: f64,
+    pub avg_rtt_ms: Option<u64>,
+}
+
+impl fmt::Display for ScenarioReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let rtt_str = match self.avg_rtt_ms {
+            Some(ms) => format!("{ms}ms"),
+            None => "N/A".to_string(),
+        };
+        write!(
+            f,
+            "=== Scenario Report ===\n\
+             mode: {}\n\
+             total_bots: {}\n\
+             success: {}\n\
+             failure: {}\n\
+             elapsed: {:.2}s\n\
+             avg_rtt: {}",
+            self.mode, self.total_bots, self.success_count,
+            self.failure_count, self.elapsed_secs, rtt_str
+        )
+    }
+}
+
+// ── Task 1: BotType 열거형 ──────────────────────────────────────────
+
+/// 봇 동작 유형을 나타내는 열거형
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BotType {
+    Normal,
+    Fickle,
+    Spammer,
+    Ghost,
+    Quitter,
+}
+
+impl BotType {
+    /// 문자열에서 BotType으로 변환
+    pub fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "normal" => Ok(BotType::Normal),
+            "fickle" => Ok(BotType::Fickle),
+            "spammer" => Ok(BotType::Spammer),
+            "ghost" => Ok(BotType::Ghost),
+            "quitter" => Ok(BotType::Quitter),
+            other => Err(format!("유효하지 않은 봇 타입: '{other}'")),
+        }
+    }
+
+    /// BotType을 문자열로 변환
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BotType::Normal => "normal",
+            BotType::Fickle => "fickle",
+            BotType::Spammer => "spammer",
+            BotType::Ghost => "ghost",
+            BotType::Quitter => "quitter",
+        }
+    }
+}
+
+// ── Task 1: RatioSpec 구조체 ────────────────────────────────────────
+
+/// 봇 타입별 비율을 저장하는 구조체
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RatioSpec {
+    /// 순서 보존을 위해 Vec 사용
+    pub entries: Vec<(BotType, u32)>,
+}
+
+impl RatioSpec {
+    /// 기본 비율 문자열
+    pub const DEFAULT: &str = "normal:40,spammer:20,fickle:20,ghost:10,quitter:10";
+
+    /// 비율 문자열을 파싱하여 RatioSpec을 생성
+    ///
+    /// 형식: `타입:숫자,타입:숫자,...`
+    /// 예: `"normal:40,spammer:20,fickle:20,ghost:10,quitter:10"`
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Err("비율 문자열이 비어 있습니다".to_string());
+        }
+
+        let mut entries = Vec::new();
+        for part in s.split(',') {
+            let part = part.trim();
+            let (type_str, ratio_str) = part
+                .split_once(':')
+                .ok_or_else(|| format!("잘못된 형식: '{part}' ('타입:숫자' 형식이어야 합니다)"))?;
+
+            let type_str = type_str.trim();
+            let ratio_str = ratio_str.trim();
+
+            let bot_type = BotType::from_str(type_str)?;
+
+            let ratio: u32 = ratio_str
+                .parse()
+                .map_err(|_| format!("비율 값이 유효한 숫자가 아닙니다: '{ratio_str}'"))?;
+
+            if ratio == 0 {
+                return Err(format!("비율 값은 1 이상이어야 합니다: '{type_str}:{ratio}'"));
+            }
+
+            entries.push((bot_type, ratio));
+        }
+
+        Ok(RatioSpec { entries })
+    }
+}
+
+impl fmt::Display for RatioSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let parts: Vec<String> = self
+            .entries
+            .iter()
+            .map(|(bt, r)| format!("{}:{}", bt.as_str(), r))
+            .collect();
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+// ── Task 2: BotAllocator 배분 로직 ──────────────────────────────────
+
+/// 총 봇 수를 비율에 따라 각 BotType별로 배분
+///
+/// 알고리즘:
+/// 1. 비율 합계 계산
+/// 2. 각 타입별 `floor(total * ratio / sum)` 계산
+/// 3. 나머지 = `total - 배분 합계`
+/// 4. 나머지를 비율이 높은 순서대로 1개씩 배분
+pub fn allocate(total: usize, spec: &RatioSpec) -> Vec<(BotType, usize)> {
+    if spec.entries.is_empty() {
+        return Vec::new();
+    }
+
+    let ratio_sum: u32 = spec.entries.iter().map(|(_, r)| *r).sum();
+
+    // 기본 floor 배분
+    let mut result: Vec<(BotType, usize, u32)> = spec
+        .entries
+        .iter()
+        .map(|(bt, r)| {
+            let allocated = (total as u64 * *r as u64 / ratio_sum as u64) as usize;
+            (*bt, allocated, *r)
+        })
+        .collect();
+
+    let allocated_sum: usize = result.iter().map(|(_, a, _)| *a).sum();
+    let mut remainder = total.saturating_sub(allocated_sum);
+
+    // 나머지를 비율이 높은 순서대로 1개씩 배분
+    // 인덱스를 비율 내림차순으로 정렬 (비율이 같으면 원래 순서 유지)
+    let mut indices: Vec<usize> = (0..result.len()).collect();
+    indices.sort_by(|&a, &b| result[b].2.cmp(&result[a].2));
+
+    let mut idx = 0;
+    while remainder > 0 {
+        result[indices[idx]].1 += 1;
+        remainder -= 1;
+        idx = (idx + 1) % indices.len();
+    }
+
+    result.into_iter().map(|(bt, a, _)| (bt, a)).collect()
+}
+
+// ── 기존 헬퍼 함수 ─────────────────────────────────────────────────
 
 /// 봇이 소켓으로 JSON 메시지 한 줄을 전송하는 헬퍼
 pub async fn send_msg(
@@ -31,20 +246,112 @@ pub async fn connect() -> Result<TcpStream> {
     Ok(TcpStream::connect(SERVER_ADDR).await?)
 }
 
+// ── Task 3: run_scenario (mixed 분기 추가) ──────────────────────────
+
 /// 전체 봇 시나리오 실행기
-pub async fn run_scenario(mode: &str, count: usize, msg_per_bot: usize) {
+///
+/// `ratio`는 mixed 모드에서만 사용된다. 단일 모드에서는 무시된다.
+pub async fn run_scenario(mode: &str, count: usize, msg_per_bot: usize, ratio: Option<&str>) {
+    if mode == "mixed" {
+        run_mixed_scenario(count, msg_per_bot, ratio).await;
+    } else {
+        run_single_scenario(mode, count, msg_per_bot).await;
+    }
+}
+
+/// mixed 모드: 비율에 따라 여러 봇 타입을 혼합 실행
+async fn run_mixed_scenario(count: usize, msg_per_bot: usize, ratio: Option<&str>) {
+    let start = Instant::now();
+
+    let spec = match ratio {
+        Some(r) => RatioSpec::parse(r).expect("유효하지 않은 ratio"),
+        None => RatioSpec::parse(RatioSpec::DEFAULT).unwrap(),
+    };
+    let allocation = allocate(count, &spec);
+
+    // 각 타입별 배분 수 로그 출력
+    for (bt, n) in &allocation {
+        info!(bot_type = bt.as_str(), count = n, "mixed 모드 봇 배분");
+    }
+
     let recv_counter = Arc::new(AtomicU64::new(0));
+    let rtt_counter = RttCounter::new();
+    let mut handles = Vec::new();
+    let mut bot_id: u64 = 0;
+
+    for (bt, n) in &allocation {
+        for _ in 0..*n {
+            let recv_counter = recv_counter.clone();
+            let rtt_counter = rtt_counter.clone();
+            let bt = *bt;
+            let id = bot_id;
+            bot_id += 1;
+
+            let handle = tokio::spawn(async move {
+                let result = match bt {
+                    BotType::Normal => {
+                        normal::run(id, msg_per_bot, recv_counter, rtt_counter).await
+                    }
+                    BotType::Fickle => fickle::run(id, msg_per_bot).await,
+                    BotType::Spammer => {
+                        spammer::run(id, msg_per_bot, recv_counter, rtt_counter).await
+                    }
+                    BotType::Ghost => ghost::run(id, msg_per_bot).await,
+                    BotType::Quitter => quitter::run(id).await,
+                };
+                if let Err(ref e) = result {
+                    tracing::warn!("봇 {id} ({}) 오류: {e}", bt.as_str());
+                }
+                result
+            });
+            handles.push(handle);
+        }
+    }
+
+    let mut success_count = 0usize;
+    let mut failure_count = 0usize;
+    for h in handles {
+        match h.await {
+            Ok(Ok(())) => success_count += 1,
+            Ok(Err(_)) => failure_count += 1,
+            Err(_join_err) => failure_count += 1,
+        }
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    let report = ScenarioReport {
+        mode: "mixed".to_string(),
+        total_bots: count,
+        success_count,
+        failure_count,
+        elapsed_secs: elapsed,
+        avg_rtt_ms: rtt_counter.average(),
+    };
+    info!("\n{report}");
+}
+
+/// 기존 단일 모드 시나리오
+async fn run_single_scenario(mode: &str, count: usize, msg_per_bot: usize) {
+    let start = Instant::now();
+
+    let recv_counter = Arc::new(AtomicU64::new(0));
+    let rtt_counter = RttCounter::new();
     let mut handles = Vec::with_capacity(count);
 
     for i in 0..count {
         let recv_counter = recv_counter.clone();
+        let rtt_counter = rtt_counter.clone();
         let mode = mode.to_string();
 
         let handle = tokio::spawn(async move {
             let result = match mode.as_str() {
-                "normal" => normal::run(i as u64, msg_per_bot, recv_counter).await,
+                "normal" => {
+                    normal::run(i as u64, msg_per_bot, recv_counter, rtt_counter).await
+                }
                 "fickle" => fickle::run(i as u64, msg_per_bot).await,
-                "spammer" => spammer::run(i as u64, msg_per_bot, recv_counter).await,
+                "spammer" => {
+                    spammer::run(i as u64, msg_per_bot, recv_counter, rtt_counter).await
+                }
                 "ghost" => ghost::run(i as u64, msg_per_bot).await,
                 "quitter" => quitter::run(i as u64).await,
                 other => {
@@ -52,17 +359,25 @@ pub async fn run_scenario(mode: &str, count: usize, msg_per_bot: usize) {
                     Ok(())
                 }
             };
-            if let Err(e) = result {
+            if let Err(ref e) = result {
                 tracing::warn!("봇 {i} 오류: {e}");
             }
+            result
         });
         handles.push(handle);
     }
 
+    let mut success_count = 0usize;
+    let mut failure_count = 0usize;
     for h in handles {
-        let _ = h.await;
+        match h.await {
+            Ok(Ok(())) => success_count += 1,
+            Ok(Err(_)) => failure_count += 1,
+            Err(_join_err) => failure_count += 1,
+        }
     }
 
+    // 기존 normal 모드 누락 검증 유지
     if mode == "normal" {
         let expected = (count * msg_per_bot) as u64;
         let received = recv_counter.load(Ordering::SeqCst);
@@ -72,5 +387,537 @@ pub async fn run_scenario(mode: &str, count: usize, msg_per_bot: usize) {
             "메시지 누락 발생! expected={expected} received={received}"
         );
         info!("누락 없음 확인");
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    let report = ScenarioReport {
+        mode: mode.to_string(),
+        total_bots: count,
+        success_count,
+        failure_count,
+        elapsed_secs: elapsed,
+        avg_rtt_ms: rtt_counter.average(),
+    };
+    info!("\n{report}");
+}
+
+
+// ── Task 5 & 6: 단위 테스트 + 속성 기반 테스트 ─────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── 5.1 RatioSpec::parse() 정상 케이스 ──────────────────────────
+
+    #[test]
+    fn parse_default_ratio() {
+        let spec = RatioSpec::parse(RatioSpec::DEFAULT).unwrap();
+        assert_eq!(spec.entries.len(), 5);
+        assert_eq!(spec.entries[0], (BotType::Normal, 40));
+        assert_eq!(spec.entries[1], (BotType::Spammer, 20));
+        assert_eq!(spec.entries[2], (BotType::Fickle, 20));
+        assert_eq!(spec.entries[3], (BotType::Ghost, 10));
+        assert_eq!(spec.entries[4], (BotType::Quitter, 10));
+    }
+
+    #[test]
+    fn parse_single_entry() {
+        let spec = RatioSpec::parse("normal:100").unwrap();
+        assert_eq!(spec.entries, vec![(BotType::Normal, 100)]);
+    }
+
+    #[test]
+    fn parse_with_whitespace() {
+        let spec = RatioSpec::parse("  normal:40 , spammer:20  ").unwrap();
+        assert_eq!(spec.entries.len(), 2);
+        assert_eq!(spec.entries[0], (BotType::Normal, 40));
+        assert_eq!(spec.entries[1], (BotType::Spammer, 20));
+    }
+
+    // ── 5.2 RatioSpec::parse() 오류 케이스 ──────────────────────────
+
+    #[test]
+    fn parse_empty_string() {
+        assert!(RatioSpec::parse("").is_err());
+    }
+
+    #[test]
+    fn parse_whitespace_only() {
+        assert!(RatioSpec::parse("   ").is_err());
+    }
+
+    #[test]
+    fn parse_bad_format_no_colon() {
+        assert!(RatioSpec::parse("normal40").is_err());
+    }
+
+    #[test]
+    fn parse_zero_ratio() {
+        assert!(RatioSpec::parse("normal:0").is_err());
+    }
+
+    #[test]
+    fn parse_invalid_bot_type() {
+        assert!(RatioSpec::parse("unknown:10").is_err());
+    }
+
+    #[test]
+    fn parse_non_numeric_ratio() {
+        assert!(RatioSpec::parse("normal:abc").is_err());
+    }
+
+    // ── 5.3 allocate() 기본 비율 + 500봇 ───────────────────────────
+
+    #[test]
+    fn allocate_default_500() {
+        let spec = RatioSpec::parse(RatioSpec::DEFAULT).unwrap();
+        let result = allocate(500, &spec);
+
+        // 합계 검증
+        let total: usize = result.iter().map(|(_, n)| *n).sum();
+        assert_eq!(total, 500);
+
+        // 비율 40:20:20:10:10 → 200:100:100:50:50
+        assert_eq!(result[0], (BotType::Normal, 200));
+        assert_eq!(result[1], (BotType::Spammer, 100));
+        assert_eq!(result[2], (BotType::Fickle, 100));
+        assert_eq!(result[3], (BotType::Ghost, 50));
+        assert_eq!(result[4], (BotType::Quitter, 50));
+    }
+
+    #[test]
+    fn allocate_default_501() {
+        // 501봇: 나머지 1개는 비율이 가장 높은 normal에 배분
+        let spec = RatioSpec::parse(RatioSpec::DEFAULT).unwrap();
+        let result = allocate(501, &spec);
+
+        let total: usize = result.iter().map(|(_, n)| *n).sum();
+        assert_eq!(total, 501);
+
+        // normal이 나머지 1개를 받아야 함
+        assert_eq!(result[0], (BotType::Normal, 201));
+    }
+
+    // ── 5.4 allocate() edge case: 봇 수 < 타입 수 ──────────────────
+
+    #[test]
+    fn allocate_fewer_bots_than_types() {
+        let spec = RatioSpec::parse(RatioSpec::DEFAULT).unwrap();
+        let result = allocate(3, &spec);
+
+        let total: usize = result.iter().map(|(_, n)| *n).sum();
+        assert_eq!(total, 3);
+
+        // 비율 높은 순서대로 배분: normal(40), spammer(20), fickle(20)
+        // floor 배분은 모두 0이므로 나머지 3개를 비율 높은 순서대로 배분
+        let normal_count = result.iter().find(|(bt, _)| *bt == BotType::Normal).unwrap().1;
+        assert!(normal_count >= 1, "비율이 가장 높은 normal은 최소 1개 배분");
+    }
+
+    #[test]
+    fn allocate_zero_bots() {
+        let spec = RatioSpec::parse(RatioSpec::DEFAULT).unwrap();
+        let result = allocate(0, &spec);
+
+        let total: usize = result.iter().map(|(_, n)| *n).sum();
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn allocate_one_bot() {
+        let spec = RatioSpec::parse(RatioSpec::DEFAULT).unwrap();
+        let result = allocate(1, &spec);
+
+        let total: usize = result.iter().map(|(_, n)| *n).sum();
+        assert_eq!(total, 1);
+    }
+
+    // ── BotType 변환 테스트 ─────────────────────────────────────────
+
+    #[test]
+    fn bot_type_roundtrip() {
+        let types = [BotType::Normal, BotType::Fickle, BotType::Spammer, BotType::Ghost, BotType::Quitter];
+        for bt in &types {
+            assert_eq!(BotType::from_str(bt.as_str()).unwrap(), *bt);
+        }
+    }
+
+    #[test]
+    fn bot_type_invalid() {
+        assert!(BotType::from_str("invalid").is_err());
+        assert!(BotType::from_str("").is_err());
+    }
+
+    // ── Task 6: 속성 기반 테스트 (proptest) ─────────────────────────
+
+    use proptest::prelude::*;
+
+    /// 유효한 BotType을 생성하는 전략
+    fn arb_bot_type() -> impl Strategy<Value = BotType> {
+        prop_oneof![
+            Just(BotType::Normal),
+            Just(BotType::Fickle),
+            Just(BotType::Spammer),
+            Just(BotType::Ghost),
+            Just(BotType::Quitter),
+        ]
+    }
+
+    /// 유효한 RatioSpec entries를 생성하는 전략 (1~5개 항목, 비율 1~100)
+    fn arb_ratio_entries() -> impl Strategy<Value = Vec<(BotType, u32)>> {
+        // 중복 없는 BotType 선택을 위해 서브셋 방식 사용
+        (1u32..=100, 1u32..=100, 1u32..=100, 1u32..=100, 1u32..=100, 1usize..=5)
+            .prop_map(|(r1, r2, r3, r4, r5, count)| {
+                let all = vec![
+                    (BotType::Normal, r1),
+                    (BotType::Spammer, r2),
+                    (BotType::Fickle, r3),
+                    (BotType::Ghost, r4),
+                    (BotType::Quitter, r5),
+                ];
+                all.into_iter().take(count).collect::<Vec<_>>()
+            })
+    }
+
+    /// 유효한 RatioSpec을 생성하는 전략
+    fn arb_ratio_spec() -> impl Strategy<Value = RatioSpec> {
+        arb_ratio_entries().prop_map(|entries| RatioSpec { entries })
+    }
+
+    // ── 6.2 Property 1: RatioSpec 라운드트립 ────────────────────────
+    // **Validates: Requirements 3.4**
+    proptest! {
+        #[test]
+        fn prop_ratio_spec_roundtrip(spec in arb_ratio_spec()) {
+            // Property 1: parse(to_string(spec)) == spec
+            let serialized = spec.to_string();
+            let parsed = RatioSpec::parse(&serialized)
+                .expect("라운드트립 파싱 실패");
+            prop_assert_eq!(parsed.entries, spec.entries);
+        }
+    }
+
+    // ── 6.3 Property 2: 유효하지 않은 입력 거부 ─────────────────────
+    // **Validates: Requirements 2.4, 3.2, 3.3**
+    proptest! {
+        #[test]
+        fn prop_invalid_bot_type_rejected(
+            invalid_name in "[a-z]{1,10}"
+                .prop_filter("유효한 봇 타입 제외",
+                    |s| !["normal","fickle","spammer","ghost","quitter"].contains(&s.as_str())),
+            ratio in 1u32..=100
+        ) {
+            // (a) 유효하지 않은 봇 타입명
+            let input = format!("{}:{}", invalid_name, ratio);
+            prop_assert!(RatioSpec::parse(&input).is_err(),
+                "유효하지 않은 봇 타입 '{}'이 허용됨", invalid_name);
+        }
+
+        #[test]
+        fn prop_bad_format_rejected(
+            word in "[a-z]{1,10}"
+        ) {
+            // (b) 콜론 없는 형식
+            prop_assert!(RatioSpec::parse(&word).is_err(),
+                "콜론 없는 형식 '{}'이 허용됨", word);
+        }
+
+        #[test]
+        fn prop_zero_ratio_rejected(
+            bot_type in arb_bot_type()
+        ) {
+            // (c) 비율 값이 0
+            let input = format!("{}:0", bot_type.as_str());
+            prop_assert!(RatioSpec::parse(&input).is_err(),
+                "비율 0이 허용됨: '{}'", input);
+        }
+    }
+
+    // ── 6.4 Property 3: 배분 합계 불변량 ────────────────────────────
+    // **Validates: Requirements 4.2**
+    proptest! {
+        #[test]
+        fn prop_allocation_sum_equals_total(
+            total in 0usize..=10000,
+            spec in arb_ratio_spec()
+        ) {
+            let result = allocate(total, &spec);
+            let sum: usize = result.iter().map(|(_, n)| *n).sum();
+            prop_assert_eq!(sum, total,
+                "배분 합계({})가 total({})과 불일치. spec={}, result={:?}",
+                sum, total, spec, result);
+        }
+    }
+
+    // ── 6.5 Property 4: 비율 비례 배분 ──────────────────────────────
+    // **Validates: Requirements 2.1, 4.1**
+    proptest! {
+        #[test]
+        fn prop_proportional_allocation(
+            total in 0usize..=10000,
+            spec in arb_ratio_spec()
+        ) {
+            let result = allocate(total, &spec);
+            let ratio_sum: u64 = spec.entries.iter().map(|(_, r)| *r as u64).sum();
+
+            for (i, (bt, count)) in result.iter().enumerate() {
+                let ratio = spec.entries[i].1 as u64;
+                let floor_val = (total as u64 * ratio / ratio_sum) as usize;
+                prop_assert!(*count >= floor_val,
+                    "{:?} 배분({})이 floor({})보다 작음. total={}, spec={}",
+                    bt, count, floor_val, total, spec);
+            }
+        }
+    }
+
+    // ── 6.6 Property 5: 나머지 배분 순서 ────────────────────────────
+    // **Validates: Requirements 4.3, 4.4**
+    proptest! {
+        #[test]
+        fn prop_remainder_allocation_order(
+            total in 0usize..=10000,
+            spec in arb_ratio_spec()
+        ) {
+            let result = allocate(total, &spec);
+            let ratio_sum: u64 = spec.entries.iter().map(|(_, r)| *r as u64).sum();
+
+            // 각 타입의 나머지(실제 배분 - floor 배분) 계산
+            let remainders: Vec<(BotType, usize, u32)> = result.iter().enumerate().map(|(i, (bt, count))| {
+                let ratio = spec.entries[i].1;
+                let floor_val = (total as u64 * ratio as u64 / ratio_sum) as usize;
+                let extra = count - floor_val;
+                (*bt, extra, ratio)
+            }).collect();
+
+            // 나머지를 받은 타입의 비율은 나머지를 받지 못한 타입의 비율 이상이어야 함
+            for got in remainders.iter().filter(|(_, extra, _)| *extra > 0) {
+                for not_got in remainders.iter().filter(|(_, extra, _)| *extra == 0) {
+                    prop_assert!(got.2 >= not_got.2,
+                        "나머지 배분 순서 위반: {:?}(비율={})이 나머지를 받았지만 {:?}(비율={})은 받지 못함",
+                        got.0, got.2, not_got.0, not_got.2);
+                }
+            }
+        }
+    }
+
+    // ── Task 4: ScenarioReport / RttCounter 단위 테스트 ─────────────
+
+    // ── 4.1 ScenarioReport Display 출력 형식 테스트 (모든 필드 포함) ─
+    #[test]
+    fn scenario_report_display_all_fields() {
+        let report = ScenarioReport {
+            mode: "normal".to_string(),
+            total_bots: 100,
+            success_count: 95,
+            failure_count: 5,
+            elapsed_secs: 12.345,
+            avg_rtt_ms: Some(42),
+        };
+        let output = format!("{report}");
+
+        assert!(output.contains("=== Scenario Report ==="));
+        assert!(output.contains("mode: normal"));
+        assert!(output.contains("total_bots: 100"));
+        assert!(output.contains("success: 95"));
+        assert!(output.contains("failure: 5"));
+        assert!(output.contains("elapsed: 12.35s"));
+        assert!(output.contains("avg_rtt: 42ms"));
+    }
+
+    // ── 4.2 ScenarioReport Display에서 avg_rtt_ms가 None일 때 "N/A" ─
+    #[test]
+    fn scenario_report_display_rtt_none_shows_na() {
+        let report = ScenarioReport {
+            mode: "ghost".to_string(),
+            total_bots: 10,
+            success_count: 10,
+            failure_count: 0,
+            elapsed_secs: 1.0,
+            avg_rtt_ms: None,
+        };
+        let output = format!("{report}");
+
+        assert!(output.contains("avg_rtt: N/A"));
+        // "ms"가 avg_rtt 라인에 나타나지 않아야 함
+        for line in output.lines() {
+            if line.starts_with("avg_rtt:") {
+                assert!(!line.contains("ms"), "None일 때 'ms'가 포함되면 안 됨");
+            }
+        }
+    }
+
+    // ── 4.3 RttCounter record/average 기본 동작 테스트 ──────────────
+    #[test]
+    fn rtt_counter_record_and_average() {
+        let counter = RttCounter::new();
+        counter.record(10);
+        counter.record(20);
+        counter.record(30);
+
+        // 평균: (10 + 20 + 30) / 3 = 20
+        assert_eq!(counter.average(), Some(20));
+    }
+
+    // ── 4.4 RttCounter 빈 상태에서 average() → None ────────────────
+    #[test]
+    fn rtt_counter_empty_average_is_none() {
+        let counter = RttCounter::new();
+        assert_eq!(counter.average(), None);
+    }
+
+    // ── Task 5: ScenarioReport / RttCounter 속성 기반 테스트 ────────
+
+    /// 유효한 ScenarioReport를 생성하는 전략
+    fn arb_scenario_report() -> impl Strategy<Value = ScenarioReport> {
+        (
+            prop_oneof![
+                Just("normal".to_string()),
+                Just("fickle".to_string()),
+                Just("spammer".to_string()),
+                Just("ghost".to_string()),
+                Just("quitter".to_string()),
+                Just("mixed".to_string()),
+            ],
+            0usize..=10000,
+            prop::option::of(0u64..=100_000),
+        )
+            .prop_flat_map(|(mode, total, avg_rtt_ms)| {
+                // success_count는 0..=total 범위에서 생성
+                (Just(mode), Just(total), 0..=total, Just(avg_rtt_ms))
+            })
+            .prop_flat_map(|(mode, total, success, avg_rtt_ms)| {
+                let failure = total - success;
+                // elapsed_secs: 0.0 ~ 3600.0
+                (Just(mode), Just(total), Just(success), Just(failure), 0.0f64..3600.0, Just(avg_rtt_ms))
+            })
+            .prop_map(|(mode, total_bots, success_count, failure_count, elapsed_secs, avg_rtt_ms)| {
+                ScenarioReport {
+                    mode,
+                    total_bots,
+                    success_count,
+                    failure_count,
+                    elapsed_secs,
+                    avg_rtt_ms,
+                }
+            })
+    }
+
+    /// Display 출력 문자열에서 ScenarioReport 필드를 파싱하는 헬퍼
+    fn parse_report_display(s: &str) -> Option<(String, usize, usize, usize, String, String)> {
+        let mut mode = None;
+        let mut total_bots = None;
+        let mut success = None;
+        let mut failure = None;
+        let mut elapsed = None;
+        let mut avg_rtt = None;
+
+        for line in s.lines() {
+            if let Some(v) = line.strip_prefix("mode: ") {
+                mode = Some(v.to_string());
+            } else if let Some(v) = line.strip_prefix("total_bots: ") {
+                total_bots = Some(v.parse::<usize>().ok()?);
+            } else if let Some(v) = line.strip_prefix("success: ") {
+                success = Some(v.parse::<usize>().ok()?);
+            } else if let Some(v) = line.strip_prefix("failure: ") {
+                failure = Some(v.parse::<usize>().ok()?);
+            } else if let Some(v) = line.strip_prefix("elapsed: ") {
+                elapsed = Some(v.to_string());
+            } else if let Some(v) = line.strip_prefix("avg_rtt: ") {
+                avg_rtt = Some(v.to_string());
+            }
+        }
+
+        Some((mode?, total_bots?, success?, failure?, elapsed?, avg_rtt?))
+    }
+
+    // ── 5.1 Property 1: 성공/실패 합계 불변량 ──────────────────────
+    // **Validates: Requirements 2.4**
+    proptest! {
+        #[test]
+        fn prop_scenario_report_success_failure_sum(
+            report in arb_scenario_report()
+        ) {
+            // Property 1: success_count + failure_count == total_bots
+            prop_assert_eq!(
+                report.success_count + report.failure_count,
+                report.total_bots,
+                "성공({}) + 실패({}) != 전체({})",
+                report.success_count, report.failure_count, report.total_bots
+            );
+        }
+    }
+
+    // ── 5.2 Property 2: Display 포맷 라운드트립 ─────────────────────
+    // **Validates: Requirements 5.3**
+    proptest! {
+        #[test]
+        fn prop_scenario_report_display_roundtrip(
+            report in arb_scenario_report()
+        ) {
+            let output = format!("{report}");
+            let parsed = parse_report_display(&output);
+            prop_assert!(parsed.is_some(), "Display 출력 파싱 실패: {}", output);
+
+            let (mode, total_bots, success, failure, elapsed_str, rtt_str) = parsed.unwrap();
+
+            prop_assert_eq!(&mode, &report.mode);
+            prop_assert_eq!(total_bots, report.total_bots);
+            prop_assert_eq!(success, report.success_count);
+            prop_assert_eq!(failure, report.failure_count);
+
+            // elapsed: "{:.2}s" 형식 검증
+            let expected_elapsed = format!("{:.2}s", report.elapsed_secs);
+            prop_assert_eq!(&elapsed_str, &expected_elapsed);
+
+            // avg_rtt 검증
+            let expected_rtt = match report.avg_rtt_ms {
+                Some(ms) => format!("{ms}ms"),
+                None => "N/A".to_string(),
+            };
+            prop_assert_eq!(&rtt_str, &expected_rtt);
+        }
+    }
+
+    // ── 5.3 Property 3: 평균 RTT 계산 정확성 ───────────────────────
+    // **Validates: Requirements 3.2, 3.3**
+    proptest! {
+        #[test]
+        fn prop_rtt_counter_average_correctness(
+            values in prop::collection::vec(1u64..=10_000, 0..100)
+        ) {
+            let counter = RttCounter::new();
+            for &v in &values {
+                counter.record(v);
+            }
+
+            if values.is_empty() {
+                prop_assert_eq!(counter.average(), None,
+                    "빈 RttCounter의 average()는 None이어야 함");
+            } else {
+                let expected_sum: u64 = values.iter().sum();
+                let expected_avg = expected_sum / values.len() as u64;
+                prop_assert_eq!(counter.average(), Some(expected_avg),
+                    "average() 불일치: values={:?}, sum={}, count={}",
+                    values, expected_sum, values.len());
+            }
+        }
+    }
+
+    // ── 5.4 Property 4: Display 출력 필드 완전성 ────────────────────
+    // **Validates: Requirements 4.2, 5.2**
+    proptest! {
+        #[test]
+        fn prop_scenario_report_display_field_completeness(
+            report in arb_scenario_report()
+        ) {
+            let output = format!("{report}");
+
+            let required_keys = ["mode:", "total_bots:", "success:", "failure:", "elapsed:", "avg_rtt:"];
+            for key in &required_keys {
+                prop_assert!(output.contains(key),
+                    "Display 출력에 '{}' 키가 누락됨. 출력:\n{}", key, output);
+            }
+        }
     }
 }

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -10,9 +10,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 use tracing::info;
 
-use crate::protocol::ClientMsg;
+use crate::protocol::{ClientMsg, N_OPTIONS};
 
 pub const SERVER_ADDR: &str = "127.0.0.1:8080";
 pub const BOT_RECV_TIMEOUT_SECS: u64 = 30;
@@ -51,6 +52,63 @@ impl RttCounter {
     }
 }
 
+// ── Vote Integrity: FickleResult 구조체 ─────────────────────────────
+
+/// fickle 봇의 실행 결과
+#[derive(Debug, Clone)]
+pub struct FickleResult {
+    /// 마지막으로 투표한 옵션 (0..N_OPTIONS)
+    pub last_vote: Option<usize>,
+    /// 마지막으로 수신한 VoteSnapshot의 counts
+    pub last_snapshot: Option<[u64; N_OPTIONS]>,
+}
+
+// ── Vote Integrity: VoteIntegrityResult 구조체 ──────────────────────
+
+/// 투표 정합성 검증 결과
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoteIntegrityResult {
+    /// 정합성 통과 여부
+    pub passed: bool,
+    /// 봇 측 기대 투표 배열
+    pub expected: [u64; N_OPTIONS],
+    /// 서버 측 VoteSnapshot counts 배열
+    pub actual: [u64; N_OPTIONS],
+    /// 검증에 참여한 fickle 봇 수
+    pub fickle_count: usize,
+}
+
+// ── Vote Integrity: 집계 순수 함수 ──────────────────────────────────
+
+/// 마지막 투표 옵션 목록을 옵션별 카운트 배열로 집계
+pub fn tally_votes(last_votes: &[Option<usize>]) -> [u64; N_OPTIONS] {
+    let mut counts = [0u64; N_OPTIONS];
+    for vote in last_votes {
+        if let Some(opt) = vote {
+            if *opt < N_OPTIONS {
+                counts[*opt] += 1;
+            }
+        }
+    }
+    counts
+}
+
+/// 봇 측 기대 배열과 서버 측 실제 배열을 비교하여 정합성 결과 생성
+pub fn check_vote_integrity(
+    expected: [u64; N_OPTIONS],
+    actual: [u64; N_OPTIONS],
+    fickle_count: usize,
+) -> VoteIntegrityResult {
+    let expected_sum: u64 = expected.iter().sum();
+    let actual_sum: u64 = actual.iter().sum();
+    VoteIntegrityResult {
+        passed: expected_sum == actual_sum,
+        expected,
+        actual,
+        fickle_count,
+    }
+}
+
 // ── Scenario Report: ScenarioReport 구조체 ──────────────────────────
 
 /// 시나리오 실행 결과 요약 리포트
@@ -62,12 +120,24 @@ pub struct ScenarioReport {
     pub failure_count: usize,
     pub elapsed_secs: f64,
     pub avg_rtt_ms: Option<u64>,
+    /// 투표 정합성 검증 결과 (fickle 봇이 있는 경우에만 Some)
+    pub vote_integrity: Option<VoteIntegrityResult>,
 }
 
 impl fmt::Display for ScenarioReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let rtt_str = match self.avg_rtt_ms {
             Some(ms) => format!("{ms}ms"),
+            None => "N/A".to_string(),
+        };
+        let vote_integrity_str = match &self.vote_integrity {
+            Some(vi) => {
+                let status = if vi.passed { "PASS" } else { "FAIL" };
+                format!(
+                    "{} (expected={:?}, actual={:?}, fickle_bots={})",
+                    status, vi.expected, vi.actual, vi.fickle_count
+                )
+            }
             None => "N/A".to_string(),
         };
         write!(
@@ -78,9 +148,10 @@ impl fmt::Display for ScenarioReport {
              success: {}\n\
              failure: {}\n\
              elapsed: {:.2}s\n\
-             avg_rtt: {}",
+             avg_rtt: {}\n\
+             vote_integrity: {}",
             self.mode, self.total_bots, self.success_count,
-            self.failure_count, self.elapsed_secs, rtt_str
+            self.failure_count, self.elapsed_secs, rtt_str, vote_integrity_str
         )
     }
 }
@@ -276,6 +347,7 @@ async fn run_mixed_scenario(count: usize, msg_per_bot: usize, ratio: Option<&str
 
     let recv_counter = Arc::new(AtomicU64::new(0));
     let rtt_counter = RttCounter::new();
+    let fickle_results: Arc<Mutex<Vec<FickleResult>>> = Arc::new(Mutex::new(Vec::new()));
     let mut handles = Vec::new();
     let mut bot_id: u64 = 0;
 
@@ -283,6 +355,7 @@ async fn run_mixed_scenario(count: usize, msg_per_bot: usize, ratio: Option<&str
         for _ in 0..*n {
             let recv_counter = recv_counter.clone();
             let rtt_counter = rtt_counter.clone();
+            let fickle_results = fickle_results.clone();
             let bt = *bt;
             let id = bot_id;
             bot_id += 1;
@@ -292,7 +365,15 @@ async fn run_mixed_scenario(count: usize, msg_per_bot: usize, ratio: Option<&str
                     BotType::Normal => {
                         normal::run(id, msg_per_bot, recv_counter, rtt_counter).await
                     }
-                    BotType::Fickle => fickle::run(id, msg_per_bot).await,
+                    BotType::Fickle => {
+                        match fickle::run(id, msg_per_bot).await {
+                            Ok(fickle_result) => {
+                                fickle_results.lock().await.push(fickle_result);
+                                Ok(())
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
                     BotType::Spammer => {
                         spammer::run(id, msg_per_bot, recv_counter, rtt_counter).await
                     }
@@ -318,6 +399,21 @@ async fn run_mixed_scenario(count: usize, msg_per_bot: usize, ratio: Option<&str
         }
     }
 
+    // 투표 정합성 검증
+    let fickle_results = fickle_results.lock().await;
+    let vote_integrity = if fickle_results.is_empty() {
+        None
+    } else {
+        let last_votes: Vec<Option<usize>> = fickle_results.iter().map(|r| r.last_vote).collect();
+        let expected = tally_votes(&last_votes);
+        let actual = fickle_results
+            .iter()
+            .rev()
+            .find_map(|r| r.last_snapshot)
+            .unwrap_or([0; N_OPTIONS]);
+        Some(check_vote_integrity(expected, actual, fickle_results.len()))
+    };
+
     let elapsed = start.elapsed().as_secs_f64();
     let report = ScenarioReport {
         mode: "mixed".to_string(),
@@ -326,6 +422,7 @@ async fn run_mixed_scenario(count: usize, msg_per_bot: usize, ratio: Option<&str
         failure_count,
         elapsed_secs: elapsed,
         avg_rtt_ms: rtt_counter.average(),
+        vote_integrity,
     };
     info!("\n{report}");
 }
@@ -336,11 +433,13 @@ async fn run_single_scenario(mode: &str, count: usize, msg_per_bot: usize) {
 
     let recv_counter = Arc::new(AtomicU64::new(0));
     let rtt_counter = RttCounter::new();
+    let fickle_results: Arc<Mutex<Vec<FickleResult>>> = Arc::new(Mutex::new(Vec::new()));
     let mut handles = Vec::with_capacity(count);
 
     for i in 0..count {
         let recv_counter = recv_counter.clone();
         let rtt_counter = rtt_counter.clone();
+        let fickle_results = fickle_results.clone();
         let mode = mode.to_string();
 
         let handle = tokio::spawn(async move {
@@ -348,7 +447,15 @@ async fn run_single_scenario(mode: &str, count: usize, msg_per_bot: usize) {
                 "normal" => {
                     normal::run(i as u64, msg_per_bot, recv_counter, rtt_counter).await
                 }
-                "fickle" => fickle::run(i as u64, msg_per_bot).await,
+                "fickle" => {
+                    match fickle::run(i as u64, msg_per_bot).await {
+                        Ok(fickle_result) => {
+                            fickle_results.lock().await.push(fickle_result);
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
+                }
                 "spammer" => {
                     spammer::run(i as u64, msg_per_bot, recv_counter, rtt_counter).await
                 }
@@ -389,6 +496,21 @@ async fn run_single_scenario(mode: &str, count: usize, msg_per_bot: usize) {
         info!("누락 없음 확인");
     }
 
+    // 투표 정합성 검증 (fickle 모드에서만)
+    let fickle_results = fickle_results.lock().await;
+    let vote_integrity = if mode == "fickle" && !fickle_results.is_empty() {
+        let last_votes: Vec<Option<usize>> = fickle_results.iter().map(|r| r.last_vote).collect();
+        let expected = tally_votes(&last_votes);
+        let actual = fickle_results
+            .iter()
+            .rev()
+            .find_map(|r| r.last_snapshot)
+            .unwrap_or([0; N_OPTIONS]);
+        Some(check_vote_integrity(expected, actual, fickle_results.len()))
+    } else {
+        None
+    };
+
     let elapsed = start.elapsed().as_secs_f64();
     let report = ScenarioReport {
         mode: mode.to_string(),
@@ -397,6 +519,7 @@ async fn run_single_scenario(mode: &str, count: usize, msg_per_bot: usize) {
         failure_count,
         elapsed_secs: elapsed,
         avg_rtt_ms: rtt_counter.average(),
+        vote_integrity,
     };
     info!("\n{report}");
 }
@@ -713,6 +836,7 @@ mod tests {
             failure_count: 5,
             elapsed_secs: 12.345,
             avg_rtt_ms: Some(42),
+            vote_integrity: None,
         };
         let output = format!("{report}");
 
@@ -735,6 +859,7 @@ mod tests {
             failure_count: 0,
             elapsed_secs: 1.0,
             avg_rtt_ms: None,
+            vote_integrity: None,
         };
         let output = format!("{report}");
 
@@ -799,6 +924,7 @@ mod tests {
                     failure_count,
                     elapsed_secs,
                     avg_rtt_ms,
+                    vote_integrity: None,
                 }
             })
     }
@@ -913,11 +1039,294 @@ mod tests {
         ) {
             let output = format!("{report}");
 
-            let required_keys = ["mode:", "total_bots:", "success:", "failure:", "elapsed:", "avg_rtt:"];
+            let required_keys = ["mode:", "total_bots:", "success:", "failure:", "elapsed:", "avg_rtt:", "vote_integrity:"];
             for key in &required_keys {
                 prop_assert!(output.contains(key),
                     "Display 출력에 '{}' 키가 누락됨. 출력:\n{}", key, output);
             }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // Task 5: 투표 정합성 단위 테스트
+    // ══════════════════════════════════════════════════════════════════
+
+    // ── 5.1 tally_votes() 기본 동작 테스트 ──────────────────────────
+
+    #[test]
+    fn tally_votes_basic() {
+        // 4명이 각각 옵션 0, 1, 2, 3에 투표
+        let votes = vec![Some(0), Some(1), Some(2), Some(3)];
+        let result = tally_votes(&votes);
+        assert_eq!(result, [1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn tally_votes_multiple_same_option() {
+        // 여러 명이 같은 옵션에 투표
+        let votes = vec![Some(0), Some(0), Some(1), Some(2), Some(2), Some(2)];
+        let result = tally_votes(&votes);
+        assert_eq!(result, [2, 1, 3, 0]);
+    }
+
+    // ── 5.2 tally_votes() 빈 입력 테스트 ───────────────────────────
+
+    #[test]
+    fn tally_votes_empty_input() {
+        let votes: Vec<Option<usize>> = vec![];
+        let result = tally_votes(&votes);
+        assert_eq!(result, [0, 0, 0, 0]);
+    }
+
+    // ── 5.3 tally_votes() None 및 범위 초과 입력 테스트 ─────────────
+
+    #[test]
+    fn tally_votes_none_excluded() {
+        let votes = vec![Some(0), None, Some(1), None];
+        let result = tally_votes(&votes);
+        assert_eq!(result, [1, 1, 0, 0]);
+    }
+
+    #[test]
+    fn tally_votes_out_of_range_excluded() {
+        // N_OPTIONS == 4이므로 4 이상은 제외
+        let votes = vec![Some(0), Some(4), Some(100), Some(3)];
+        let result = tally_votes(&votes);
+        assert_eq!(result, [1, 0, 0, 1]);
+    }
+
+    #[test]
+    fn tally_votes_all_none() {
+        let votes = vec![None, None, None];
+        let result = tally_votes(&votes);
+        assert_eq!(result, [0, 0, 0, 0]);
+    }
+
+    // ── 5.4 check_vote_integrity() PASS 케이스 테스트 ───────────────
+
+    #[test]
+    fn check_vote_integrity_pass() {
+        let expected = [3, 2, 1, 4]; // 총합 10
+        let actual = [2, 3, 1, 4];   // 총합 10
+        let result = check_vote_integrity(expected, actual, 10);
+        assert!(result.passed);
+        assert_eq!(result.expected, expected);
+        assert_eq!(result.actual, actual);
+        assert_eq!(result.fickle_count, 10);
+    }
+
+    // ── 5.5 check_vote_integrity() FAIL 케이스 테스트 ───────────────
+
+    #[test]
+    fn check_vote_integrity_fail() {
+        let expected = [3, 2, 1, 4]; // 총합 10
+        let actual = [2, 2, 1, 4];   // 총합 9
+        let result = check_vote_integrity(expected, actual, 10);
+        assert!(!result.passed);
+        assert_eq!(result.expected, expected);
+        assert_eq!(result.actual, actual);
+        assert_eq!(result.fickle_count, 10);
+    }
+
+    // ── 5.6 ScenarioReport Display에 vote_integrity PASS/FAIL/N/A 출력 테스트 ─
+
+    #[test]
+    fn scenario_report_display_vote_integrity_pass() {
+        let report = ScenarioReport {
+            mode: "fickle".to_string(),
+            total_bots: 10,
+            success_count: 10,
+            failure_count: 0,
+            elapsed_secs: 1.0,
+            avg_rtt_ms: None,
+            vote_integrity: Some(VoteIntegrityResult {
+                passed: true,
+                expected: [3, 2, 3, 2],
+                actual: [3, 2, 3, 2],
+                fickle_count: 10,
+            }),
+        };
+        let output = format!("{report}");
+        assert!(output.contains("vote_integrity: PASS"));
+    }
+
+    #[test]
+    fn scenario_report_display_vote_integrity_fail() {
+        let report = ScenarioReport {
+            mode: "fickle".to_string(),
+            total_bots: 10,
+            success_count: 10,
+            failure_count: 0,
+            elapsed_secs: 1.0,
+            avg_rtt_ms: None,
+            vote_integrity: Some(VoteIntegrityResult {
+                passed: false,
+                expected: [3, 2, 3, 2],
+                actual: [2, 2, 3, 2],
+                fickle_count: 10,
+            }),
+        };
+        let output = format!("{report}");
+        assert!(output.contains("vote_integrity: FAIL"));
+    }
+
+    #[test]
+    fn scenario_report_display_vote_integrity_na() {
+        let report = ScenarioReport {
+            mode: "normal".to_string(),
+            total_bots: 10,
+            success_count: 10,
+            failure_count: 0,
+            elapsed_secs: 1.0,
+            avg_rtt_ms: None,
+            vote_integrity: None,
+        };
+        let output = format!("{report}");
+        assert!(output.contains("vote_integrity: N/A"));
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // Task 6: 투표 정합성 속성 기반 테스트 (Property-Based Tests)
+    // ══════════════════════════════════════════════════════════════════
+
+    /// 유효한 Option<usize> 투표 목록을 생성하는 전략
+    /// Some(0..N_OPTIONS), Some(범위 초과), None을 혼합
+    fn arb_vote_list() -> impl Strategy<Value = Vec<Option<usize>>> {
+        prop::collection::vec(
+            prop_oneof![
+                // 유효한 투표 (0..N_OPTIONS)
+                (0..N_OPTIONS).prop_map(Some),
+                // 범위 초과 투표
+                (N_OPTIONS..N_OPTIONS + 100).prop_map(Some),
+                // None (투표 없음)
+                Just(None),
+            ],
+            0..200,
+        )
+    }
+
+    // ── 6.1 Property 1: 투표 집계 합계 불변량 ───────────────────────
+    // **Validates: Requirements 2.2**
+    proptest! {
+        #[test]
+        fn prop_tally_votes_sum_invariant(votes in arb_vote_list()) {
+            let result = tally_votes(&votes);
+            let result_sum: u64 = result.iter().sum();
+
+            // 유효 투표 수: Some(v)이고 v < N_OPTIONS인 항목의 수
+            let valid_count = votes.iter()
+                .filter(|v| matches!(v, Some(opt) if *opt < N_OPTIONS))
+                .count() as u64;
+
+            prop_assert_eq!(result_sum, valid_count,
+                "tally_votes 결과 총합({})이 유효 투표 수({})와 불일치. votes={:?}",
+                result_sum, valid_count, votes);
+        }
+    }
+
+    // ── 6.2 Property 2: 정합성 판정 일관성 ──────────────────────────
+    // **Validates: Requirements 4.1, 4.2, 4.3**
+    proptest! {
+        #[test]
+        fn prop_check_vote_integrity_consistency(
+            expected in prop::array::uniform4(0u64..1000),
+            actual in prop::array::uniform4(0u64..1000),
+            fickle_count in 1usize..100
+        ) {
+            let result = check_vote_integrity(expected, actual, fickle_count);
+
+            let expected_sum: u64 = expected.iter().sum();
+            let actual_sum: u64 = actual.iter().sum();
+            let should_pass = expected_sum == actual_sum;
+
+            prop_assert_eq!(result.passed, should_pass,
+                "passed({})가 총합 비교({} == {})와 불일치. expected={:?}, actual={:?}",
+                result.passed, expected_sum, actual_sum, expected, actual);
+        }
+    }
+
+    // ── 6.3 Property 3: Display 라운드트립 (vote_integrity 상태) ────
+    // **Validates: Requirements 5.4**
+    proptest! {
+        #[test]
+        fn prop_vote_integrity_display_roundtrip(
+            passed in proptest::bool::ANY,
+            expected in prop::array::uniform4(0u64..100),
+            actual in prop::array::uniform4(0u64..100),
+            fickle_count in 1usize..50
+        ) {
+            // vote_integrity가 Some인 경우
+            let report = ScenarioReport {
+                mode: "fickle".to_string(),
+                total_bots: 10,
+                success_count: 10,
+                failure_count: 0,
+                elapsed_secs: 1.0,
+                avg_rtt_ms: None,
+                vote_integrity: Some(VoteIntegrityResult {
+                    passed,
+                    expected,
+                    actual,
+                    fickle_count,
+                }),
+            };
+            let output = format!("{report}");
+
+            // vote_integrity 라인에서 상태 복원
+            let vi_line = output.lines()
+                .find(|l| l.starts_with("vote_integrity:"))
+                .expect("vote_integrity 라인 없음");
+
+            if passed {
+                prop_assert!(vi_line.contains("PASS"),
+                    "passed=true인데 PASS가 없음: {}", vi_line);
+                prop_assert!(!vi_line.contains("FAIL"),
+                    "passed=true인데 FAIL이 있음: {}", vi_line);
+            } else {
+                prop_assert!(vi_line.contains("FAIL"),
+                    "passed=false인데 FAIL이 없음: {}", vi_line);
+            }
+        }
+
+        #[test]
+        fn prop_vote_integrity_na_display_roundtrip(
+            mode in prop_oneof![
+                Just("normal".to_string()),
+                Just("ghost".to_string()),
+                Just("quitter".to_string()),
+            ]
+        ) {
+            // vote_integrity가 None인 경우
+            let report = ScenarioReport {
+                mode,
+                total_bots: 10,
+                success_count: 10,
+                failure_count: 0,
+                elapsed_secs: 1.0,
+                avg_rtt_ms: None,
+                vote_integrity: None,
+            };
+            let output = format!("{report}");
+
+            let vi_line = output.lines()
+                .find(|l| l.starts_with("vote_integrity:"))
+                .expect("vote_integrity 라인 없음");
+
+            prop_assert!(vi_line.contains("N/A"),
+                "vote_integrity=None인데 N/A가 없음: {}", vi_line);
+        }
+    }
+
+    // ── 6.4 Property 4: tally_votes 멱등성 ──────────────────────────
+    // **Validates: Requirements 2.2**
+    proptest! {
+        #[test]
+        fn prop_tally_votes_idempotent(votes in arb_vote_list()) {
+            let result1 = tally_votes(&votes);
+            let result2 = tally_votes(&votes);
+            prop_assert_eq!(result1, result2,
+                "동일 입력에 대해 tally_votes 결과가 다름: {:?} vs {:?}",
+                result1, result2);
         }
     }
 }

--- a/src/bot/normal.rs
+++ b/src/bot/normal.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, BufReader, BufWriter};
+use tokio::time::timeout;
+use tracing::warn;
 
-use super::{connect, send_msg};
+use super::{connect, send_msg, RttCounter, BOT_RECV_TIMEOUT_SECS};
 use crate::protocol::ClientMsg;
 
 fn now_ms() -> u64 {
@@ -14,39 +16,79 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-pub async fn run(id: u64, msg_count: usize, recv_counter: Arc<AtomicU64>) -> Result<()> {
+pub async fn run(
+    id: u64,
+    msg_count: usize,
+    recv_counter: Arc<AtomicU64>,
+    rtt_counter: Arc<RttCounter>,
+) -> Result<()> {
     let stream = connect().await?;
     let (reader, writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
     let mut writer = BufWriter::new(writer);
 
-    // 수신 task: msg_count개 수신하면 스스로 종료
-    let target = format!("bot_{id}_msg_");
-    let recv_task = tokio::spawn(async move {
-        let mut count = 0u64;
-        while let Ok(Some(line)) = lines.next_line().await {
-            if line.contains(&target) {
-                count += 1;
-                if count >= msg_count as u64 {
-                    break;
-                }
-            }
-        }
-        count
-    });
+    // 송신 시각을 seq별로 기록
+    let mut send_timestamps: Vec<u64> = Vec::with_capacity(msg_count);
 
     // 송신: 클라이언트 송신 시각 client_ts 포함
     for seq in 0..msg_count {
+        let ts = now_ms();
+        send_timestamps.push(ts);
         let text = format!("bot_{id}_msg_{seq}");
         send_msg(
             &mut writer,
             &ClientMsg::Chat {
                 text,
-                client_ts: now_ms(),
+                client_ts: ts,
             },
         )
         .await?;
     }
+
+    // 수신 task: msg_count개 수신하면 스스로 종료 (타임아웃 적용)
+    let target = format!("bot_{id}_msg_");
+    let recv_task = tokio::spawn(async move {
+        let count = Arc::new(AtomicU64::new(0));
+        let count_inner = count.clone();
+
+        let result = timeout(Duration::from_secs(BOT_RECV_TIMEOUT_SECS), async move {
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.contains(&target) {
+                    // RTT 계산: 수신 시점 - 송신 시점
+                    // 메시지 텍스트에서 seq 번호를 추출하여 송신 시각 조회
+                    let recv_ts = now_ms();
+                    if let Some(seq) = extract_seq(&line, &target) {
+                        if let Some(&send_ts) = send_timestamps.get(seq) {
+                            if recv_ts >= send_ts {
+                                rtt_counter.record(recv_ts - send_ts);
+                            }
+                        }
+                    }
+
+                    let c = count_inner.fetch_add(1, Ordering::Relaxed) + 1;
+                    if c >= msg_count as u64 {
+                        break;
+                    }
+                }
+            }
+            count_inner.load(Ordering::Relaxed)
+        })
+        .await;
+
+        match result {
+            Ok(c) => c,
+            Err(_) => {
+                let received = count.load(Ordering::Relaxed);
+                warn!(
+                    bot_id = id,
+                    expected = msg_count,
+                    received = received,
+                    "recv_task 타임아웃: {received}/{msg_count} 수신"
+                );
+                received
+            }
+        }
+    });
 
     // recv 완료 대기 후 writer 종료
     let received = recv_task.await.unwrap_or(0);
@@ -54,4 +96,14 @@ pub async fn run(id: u64, msg_count: usize, recv_counter: Arc<AtomicU64>) -> Res
     recv_counter.fetch_add(received, Ordering::Relaxed);
 
     Ok(())
+}
+
+/// 수신된 라인에서 target 접두사 이후의 seq 번호를 추출
+fn extract_seq(line: &str, target: &str) -> Option<usize> {
+    // 라인은 JSON이므로 target 문자열 이후의 숫자를 파싱
+    let idx = line.find(target)?;
+    let after = &line[idx + target.len()..];
+    // seq 번호는 숫자로 시작하고 비숫자 문자(", } 등)에서 끝남
+    let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    num_str.parse().ok()
 }

--- a/src/bot/spammer.rs
+++ b/src/bot/spammer.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, BufReader, BufWriter};
 
-use super::{connect, send_msg};
+use super::{connect, send_msg, RttCounter};
 use crate::protocol::ClientMsg;
 
 fn now_ms() -> u64 {
@@ -14,11 +14,34 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-pub async fn run(id: u64, msg_count: usize, recv_counter: Arc<AtomicU64>) -> Result<()> {
+pub async fn run(
+    id: u64,
+    msg_count: usize,
+    recv_counter: Arc<AtomicU64>,
+    rtt_counter: Arc<RttCounter>,
+) -> Result<()> {
     let stream = connect().await?;
     let (reader, writer) = stream.into_split();
     let mut lines = BufReader::new(reader).lines();
     let mut writer = BufWriter::new(writer);
+
+    // 송신 시각을 seq별로 기록
+    let mut send_timestamps: Vec<u64> = Vec::with_capacity(msg_count);
+
+    // 송신: 클라이언트 송신 시각 client_ts 포함
+    for seq in 0..msg_count {
+        let ts = now_ms();
+        send_timestamps.push(ts);
+        let text = format!("bot_{id}_msg_{seq}");
+        send_msg(
+            &mut writer,
+            &ClientMsg::Chat {
+                text,
+                client_ts: ts,
+            },
+        )
+        .await?;
+    }
 
     // 수신 task: msg_count개 수신하면 스스로 종료
     let target = format!("bot_{id}_msg_");
@@ -26,6 +49,16 @@ pub async fn run(id: u64, msg_count: usize, recv_counter: Arc<AtomicU64>) -> Res
         let mut count = 0u64;
         while let Ok(Some(line)) = lines.next_line().await {
             if line.contains(&target) {
+                // RTT 계산: 수신 시점 - 송신 시점
+                let recv_ts = now_ms();
+                if let Some(seq) = extract_seq(&line, &target) {
+                    if let Some(&send_ts) = send_timestamps.get(seq) {
+                        if recv_ts >= send_ts {
+                            rtt_counter.record(recv_ts - send_ts);
+                        }
+                    }
+                }
+
                 count += 1;
                 if count >= msg_count as u64 {
                     break;
@@ -35,23 +68,18 @@ pub async fn run(id: u64, msg_count: usize, recv_counter: Arc<AtomicU64>) -> Res
         count
     });
 
-    // 송신: 클라이언트 송신 시각 client_ts 포함
-    for seq in 0..msg_count {
-        let text = format!("bot_{id}_msg_{seq}");
-        send_msg(
-            &mut writer,
-            &ClientMsg::Chat {
-                text,
-                client_ts: now_ms(),
-            },
-        )
-        .await?;
-    }
-
     // recv 완료 대기 후 writer 종료
     let received = recv_task.await.unwrap_or(0);
     drop(writer);
     recv_counter.fetch_add(received, Ordering::Relaxed);
 
     Ok(())
+}
+
+/// 수신된 라인에서 target 접두사 이후의 seq 번호를 추출
+fn extract_seq(line: &str, target: &str) -> Option<usize> {
+    let idx = line.find(target)?;
+    let after = &line[idx + target.len()..];
+    let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    num_str.parse().ok()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod bot;
+pub mod client;
+pub mod metrics;
+pub mod protocol;
+pub mod room;
+pub mod server;
+pub mod tui;
+pub mod vote;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,8 @@
-mod bot;
-mod client;
-mod metrics;
-mod protocol;
-mod room;
-mod server;
-mod tui;
-mod vote;
-
 use std::time::Duration;
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
+
+use rust_projects::{bot, metrics, room, server, tui, vote};
 
 #[derive(Parser)]
 #[command(name = "chat-server")]
@@ -35,12 +28,15 @@ enum Command {
         /// 봇 수
         #[arg(long, default_value_t = 500)]
         count: usize,
-        /// 봇 모드: normal | fickle | spammer | ghost | quitter
+        /// 봇 모드: normal | fickle | spammer | ghost | quitter | mixed
         #[arg(long, default_value = "normal")]
         mode: String,
         /// 봇 1개당 메시지(또는 투표) 수
         #[arg(long, default_value_t = 100)]
         msg: usize,
+        /// 봇 타입별 비율 (mixed 모드 전용). 예: "normal:40,spammer:20,fickle:20,ghost:10,quitter:10"
+        #[arg(long)]
+        ratio: Option<String>,
     },
 }
 
@@ -63,8 +59,8 @@ async fn main() -> anyhow::Result<()> {
         Command::Client { addr } => {
             tui::run(&addr).await?;
         }
-        Command::BotTest { count, mode, msg } => {
-            bot::run_scenario(&mode, count, msg).await;
+        Command::BotTest { count, mode, msg, ratio } => {
+            bot::run_scenario(&mode, count, msg, ratio.as_deref()).await;
         }
     }
 

--- a/src/room.rs
+++ b/src/room.rs
@@ -19,7 +19,12 @@ pub struct Room {
 
 impl Room {
     pub fn new() -> Arc<Self> {
-        let (tx, _) = broadcast::channel(BROADCAST_CAP);
+        Self::new_with_capacity(BROADCAST_CAP)
+    }
+
+    /// 지정된 broadcast 채널 용량으로 Room 생성
+    pub fn new_with_capacity(capacity: usize) -> Arc<Self> {
+        let (tx, _) = broadcast::channel(capacity);
         Arc::new(Self {
             tx,
             clients: Arc::new(RwLock::new(HashMap::new())),

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,6 +19,16 @@ pub static CONN_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 pub async fn run(addr: &str, room: Arc<Room>, vote: Arc<VoteBoard>, metrics: Arc<Metrics>) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr).await?;
+    run_with_listener(listener, room, vote, metrics).await
+}
+
+pub async fn run_with_listener(
+    listener: TcpListener,
+    room: Arc<Room>,
+    vote: Arc<VoteBoard>,
+    metrics: Arc<Metrics>,
+) -> anyhow::Result<()> {
+    let addr = listener.local_addr()?;
     info!("서버 시작: {addr}");
 
     loop {

--- a/tests/recv_task_timeout_test.rs
+++ b/tests/recv_task_timeout_test.rs
@@ -1,0 +1,395 @@
+/// Bug Condition Exploration Test: recv_task 무한 대기 버그
+///
+/// **Validates: Requirements 1.1, 1.2, 1.3**
+///
+/// 이 테스트는 수정 전 코드에서 반드시 실패해야 한다.
+/// 실패가 버그 존재를 확인하는 것이다.
+///
+/// Bug Condition: actual_available_messages < msg_count AND connection_alive = true
+/// 일 때 recv_task가 BOT_RECV_TIMEOUT_SECS 이내에 종료해야 하지만,
+/// 현재 코드에는 타임아웃이 없어 무한 대기가 발생한다.
+
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+/// recv_task의 핵심 로직을 재현하는 헬퍼.
+/// 바이너리 크레이트이므로 내부 모듈에 직접 접근할 수 없어
+/// src/bot/normal.rs의 recv_task 로직을 동일하게 구현한다.
+///
+/// 이 함수는 수정된 코드의 recv_task와 동일한 패턴을 사용한다:
+/// - tokio::time::timeout으로 수신 루프 전체를 감싼다
+/// - `while let Ok(Some(line)) = lines.next_line().await` 루프
+/// - target 문자열 매칭으로 count 증가
+/// - count >= msg_count 시 break
+/// - 타임아웃(3초, 테스트용) 발생 시 현재까지 수신된 count를 반환
+async fn recv_task_current(
+    lines: &mut tokio::io::Lines<BufReader<tokio::net::tcp::OwnedReadHalf>>,
+    target: &str,
+    msg_count: u64,
+) -> u64 {
+    // 테스트용 타임아웃: 3초 (실제 코드는 BOT_RECV_TIMEOUT_SECS=30초)
+    let recv_timeout = Duration::from_secs(3);
+    let count = Arc::new(AtomicU64::new(0));
+    let count_inner = count.clone();
+    let target = target.to_string();
+
+    let result = tokio::time::timeout(recv_timeout, async move {
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.contains(&target) {
+                let c = count_inner.fetch_add(1, Ordering::Relaxed) + 1;
+                if c >= msg_count {
+                    break;
+                }
+            }
+        }
+        count_inner.load(Ordering::Relaxed)
+    })
+    .await;
+
+    match result {
+        Ok(c) => c,
+        Err(_) => {
+            // 타임아웃 발생: 현재까지 수신된 count를 반환
+            count.load(Ordering::Relaxed)
+        }
+    }
+}
+
+/// Property 1: Bug Condition - recv_task 무한 대기 버그
+///
+/// **Validates: Requirements 1.1, 1.2, 1.3**
+///
+/// 시나리오: msg_count=10으로 설정하고 서버가 5개만 전송 후 연결을 유지
+/// 기대 동작: recv_task가 BOT_RECV_TIMEOUT_SECS(여기서는 3초) 이내에 종료
+/// 수정 전 코드: 타임아웃이 없어 무한 대기 발생 → 테스트 실패 (이것이 정상)
+#[tokio::test]
+async fn test_bug_condition_recv_task_hangs_on_partial_messages() {
+    let msg_count: u64 = 10;
+    let actual_available: u64 = 5;
+    // 테스트용 짧은 타임아웃 (수정 후 BOT_RECV_TIMEOUT_SECS에 해당)
+    let test_timeout = Duration::from_secs(3);
+
+    // 가짜 서버: 임의 포트에 바인드
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let bot_id: u64 = 42;
+    let target = format!("bot_{bot_id}_msg_");
+
+    // 서버 태스크: actual_available개의 메시지만 전송 후 연결 유지 (EOF 미발생)
+    let server_handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (_, mut writer) = stream.into_split();
+
+        // actual_available개의 메시지를 Chat JSON 형식으로 전송
+        for seq in 0..actual_available {
+            let chat_msg = serde_json::json!({
+                "type": "chat",
+                "from": 999,
+                "nick": null,
+                "text": format!("bot_{bot_id}_msg_{seq}"),
+                "sent_at": 1234567890u64
+            });
+            let mut line = serde_json::to_string(&chat_msg).unwrap();
+            line.push('\n');
+            writer.write_all(line.as_bytes()).await.unwrap();
+            writer.flush().await.unwrap();
+        }
+
+        // 연결을 유지한 채 대기 (EOF를 보내지 않음)
+        // 이것이 Bug Condition의 핵심: connection_alive = true
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    });
+
+    // 봇(클라이언트) 측: 서버에 연결하고 recv_task 실행
+    let client_stream = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+    let (reader, _writer) = client_stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    // 수정 전 코드의 recv_task를 재현하여 실행
+    // tokio::time::timeout으로 감싸서 무한 대기를 감지
+    let result = tokio::time::timeout(
+        test_timeout,
+        recv_task_current(&mut lines, &target, msg_count),
+    )
+    .await;
+
+    // 정리
+    server_handle.abort();
+
+    // 검증:
+    // - 수정 후 기대 동작: recv_task가 타임아웃 이내에 종료하고 actual_available(5)를 반환
+    // - 수정 전 현재 동작: 타임아웃이 없어 recv_task가 무한 대기 → timeout Err 발생
+    //
+    // 이 assert는 "recv_task가 타임아웃 이내에 정상 종료하고 올바른 count를 반환"하는지 검증한다.
+    // 수정 전 코드에서는 무한 대기로 인해 timeout이 발생하여 이 assert가 실패한다.
+    // → 실패 = 버그 존재 증명 (이것이 정상)
+    assert!(
+        result.is_ok(),
+        "recv_task가 {test_timeout:?} 이내에 종료되지 않았습니다. \
+         Bug Condition 확인: msg_count={msg_count}, actual_available={actual_available}, \
+         connection_alive=true → recv_task가 타임아웃 없이 무한 대기합니다."
+    );
+
+    let received = result.unwrap();
+    assert_eq!(
+        received, actual_available,
+        "recv_task가 수신한 메시지 수({received})가 \
+         실제 전송된 메시지 수({actual_available})와 다릅니다."
+    );
+}
+
+/// Bug Condition 변형: 서버가 메시지를 전혀 보내지 않고 연결만 유지
+///
+/// **Validates: Requirements 1.2**
+///
+/// 시나리오: msg_count=10, 서버가 0개 전송, 연결 유지
+/// 수정 전 코드: 첫 번째 메시지부터 무한 대기 → 테스트 실패
+#[tokio::test]
+async fn test_bug_condition_recv_task_hangs_on_zero_messages() {
+    let msg_count: u64 = 10;
+    let test_timeout = Duration::from_secs(3);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let bot_id: u64 = 99;
+    let target = format!("bot_{bot_id}_msg_");
+
+    // 서버: 메시지를 전혀 보내지 않고 연결만 유지
+    let server_handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (_reader, _writer) = stream.into_split();
+        // 연결 유지, 아무것도 전송하지 않음
+        tokio::time::sleep(Duration::from_secs(30)).await;
+    });
+
+    let client_stream = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+    let (reader, _writer) = client_stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    let result = tokio::time::timeout(
+        test_timeout,
+        recv_task_current(&mut lines, &target, msg_count),
+    )
+    .await;
+
+    server_handle.abort();
+
+    assert!(
+        result.is_ok(),
+        "recv_task가 {test_timeout:?} 이내에 종료되지 않았습니다. \
+         Bug Condition 확인: msg_count={msg_count}, actual_available=0, \
+         connection_alive=true → recv_task가 타임아웃 없이 무한 대기합니다."
+    );
+
+    let received = result.unwrap();
+    assert_eq!(
+        received, 0,
+        "서버가 메시지를 전혀 보내지 않았으므로 수신 count는 0이어야 합니다."
+    );
+}
+
+// ============================================================================
+// Property 2: Preservation - 정상 수신 시 기존 동작 보존
+// ============================================================================
+
+use proptest::prelude::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// **Validates: Requirements 3.1, 3.2, 3.3**
+///
+/// Property 2: Preservation - 정상 수신 시 기존 동작 보존
+///
+/// NOT isBugCondition(input)인 모든 입력에 대해:
+/// - 모든 메시지가 정상 수신되면 msg_count개 수신 후 즉시 종료하고 count를 반환
+/// - 서버가 연결을 정상 종료(EOF)하면 루프가 종료
+/// - recv_counter에 수신된 count가 정확히 누적
+
+/// 정상 수신 시나리오를 위한 헬퍼: 서버가 msg_count개 메시지를 모두 전송하고 연결 종료
+async fn run_normal_recv_scenario(msg_count: u64) -> (u64, Duration) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let bot_id: u64 = 1;
+    let target = format!("bot_{bot_id}_msg_");
+
+    let server_handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (_, mut writer) = stream.into_split();
+
+        // msg_count개의 메시지를 모두 전송
+        for seq in 0..msg_count {
+            let chat_msg = serde_json::json!({
+                "type": "chat",
+                "from": 999,
+                "nick": null,
+                "text": format!("bot_{bot_id}_msg_{seq}"),
+                "sent_at": 1234567890u64
+            });
+            let mut line = serde_json::to_string(&chat_msg).unwrap();
+            line.push('\n');
+            writer.write_all(line.as_bytes()).await.unwrap();
+        }
+        writer.flush().await.unwrap();
+        // 모든 메시지 전송 후 연결 종료 (EOF) — 정상 시나리오
+        drop(writer);
+    });
+
+    let client_stream = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+    let (reader, _writer) = client_stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    let start = std::time::Instant::now();
+    let received = recv_task_current(&mut lines, &target, msg_count).await;
+    let elapsed = start.elapsed();
+
+    let _ = server_handle.await;
+    (received, elapsed)
+}
+
+/// EOF 시나리오를 위한 헬퍼: 서버가 일부 메시지만 전송 후 연결 종료 (EOF)
+/// isBugCondition = false: connection_alive = false이므로 버그 조건이 아님
+async fn run_eof_recv_scenario(msg_count: u64, actual_send: u64) -> u64 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+
+    let bot_id: u64 = 2;
+    let target = format!("bot_{bot_id}_msg_");
+
+    let server_handle = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (_, mut writer) = stream.into_split();
+
+        // actual_send개의 메시지만 전송
+        for seq in 0..actual_send {
+            let chat_msg = serde_json::json!({
+                "type": "chat",
+                "from": 999,
+                "nick": null,
+                "text": format!("bot_{bot_id}_msg_{seq}"),
+                "sent_at": 1234567890u64
+            });
+            let mut line = serde_json::to_string(&chat_msg).unwrap();
+            line.push('\n');
+            writer.write_all(line.as_bytes()).await.unwrap();
+        }
+        writer.flush().await.unwrap();
+        // 연결 정상 종료 (EOF 발생) — NOT isBugCondition
+        drop(writer);
+    });
+
+    let client_stream = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+    let (reader, _writer) = client_stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    let received = recv_task_current(&mut lines, &target, msg_count).await;
+
+    let _ = server_handle.await;
+    received
+}
+
+/// Property 2.1: 정상 수신 보존 — 모든 메시지가 도착하면 msg_count개 수신 후 즉시 종료
+///
+/// **Validates: Requirements 3.1**
+///
+/// FOR ALL msg_count in 1..=50:
+///   서버가 msg_count개 메시지를 모두 전송하고 연결 종료하면
+///   recv_task는 msg_count를 반환하고 즉시 종료해야 한다
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+    #[test]
+    fn prop_preservation_normal_recv_returns_exact_count(msg_count in 1u64..=50) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (received, elapsed) = rt.block_on(run_normal_recv_scenario(msg_count));
+
+        // 정확히 msg_count개를 수신해야 한다
+        prop_assert_eq!(
+            received, msg_count,
+            "정상 수신 시 recv_task가 msg_count({})개를 반환해야 하지만 {}개를 반환했습니다",
+            msg_count, received
+        );
+
+        // 즉시 종료해야 한다 (5초 이내 — 네트워크 오버헤드 감안)
+        prop_assert!(
+            elapsed < Duration::from_secs(5),
+            "정상 수신 시 recv_task가 즉시 종료해야 하지만 {:?} 소요되었습니다",
+            elapsed
+        );
+    }
+}
+
+/// Property 2.2: EOF 처리 보존 — 서버가 연결을 정상 종료하면 루프가 종료
+///
+/// **Validates: Requirements 3.2**
+///
+/// FOR ALL (msg_count, actual_send) where actual_send <= msg_count:
+///   서버가 actual_send개 전송 후 연결 종료(EOF)하면
+///   recv_task는 actual_send를 반환하고 루프가 종료되어야 한다
+///   (connection_alive = false이므로 isBugCondition = false)
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+    #[test]
+    fn prop_preservation_eof_terminates_loop(
+        msg_count in 1u64..=50,
+        send_ratio in 0.0f64..=1.0,
+    ) {
+        let actual_send = ((msg_count as f64) * send_ratio).round() as u64;
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let result = rt.block_on(async {
+            tokio::time::timeout(
+                Duration::from_secs(5),
+                run_eof_recv_scenario(msg_count, actual_send),
+            ).await
+        });
+
+        // EOF 시 루프가 반드시 종료되어야 한다 (타임아웃 발생하면 안 됨)
+        prop_assert!(
+            result.is_ok(),
+            "EOF 시나리오에서 recv_task가 5초 이내에 종료되지 않았습니다. \
+             msg_count={}, actual_send={}",
+            msg_count, actual_send
+        );
+
+        let received = result.unwrap();
+        // EOF 전에 전송된 메시지 수만큼 수신해야 한다
+        prop_assert_eq!(
+            received, actual_send,
+            "EOF 시나리오에서 recv_task가 actual_send({})를 반환해야 하지만 {}를 반환했습니다. \
+             msg_count={}",
+            actual_send, received, msg_count
+        );
+    }
+}
+
+/// Property 2.3: recv_counter 누적 보존 — 수신된 count가 정확히 누적
+///
+/// **Validates: Requirements 3.3**
+///
+/// FOR ALL msg_count in 1..=30:
+///   recv_task가 반환한 count를 recv_counter에 fetch_add하면
+///   recv_counter의 값이 정확히 count만큼 증가해야 한다
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+    #[test]
+    fn prop_preservation_recv_counter_accumulates_correctly(msg_count in 1u64..=30) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let recv_counter = Arc::new(AtomicU64::new(0));
+
+        let (received, _elapsed) = rt.block_on(run_normal_recv_scenario(msg_count));
+
+        // recv_counter에 누적 (src/bot/normal.rs의 run 함수와 동일한 패턴)
+        recv_counter.fetch_add(received, Ordering::Relaxed);
+
+        let counter_value = recv_counter.load(Ordering::SeqCst);
+        prop_assert_eq!(
+            counter_value, msg_count,
+            "recv_counter에 누적된 값({})이 msg_count({})와 다릅니다",
+            counter_value, msg_count
+        );
+    }
+}

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -1,0 +1,168 @@
+//! 통합 부하 테스트 — 100 / 300 / 500명 시나리오
+//!
+//! 각 테스트 케이스는 서버를 별도 tokio task로 기동하고,
+//! Normal_Bot N개를 실행한 뒤 메시지 누락률 0%를 assert한다.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::net::TcpStream;
+use tokio::task::JoinHandle;
+
+use rust_projects::metrics::Metrics;
+use rust_projects::room::Room;
+use rust_projects::server::run_with_listener;
+use rust_projects::vote::VoteBoard;
+
+// ── 헬퍼 함수 ──────────────────────────────────────────────────────
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// 서버를 spawn하고 실제 바인딩된 주소를 반환
+async fn spawn_server() -> (SocketAddr, JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("서버 바인딩 실패");
+    let addr = listener.local_addr().unwrap();
+    // 부하 테스트용 대용량 broadcast 채널
+    // 500봇 × 10메시지 = 5000 + Presence 이벤트 등 여유
+    let room = Room::new_with_capacity(65536);
+    let vote = VoteBoard::new();
+    let metrics = Metrics::new();
+
+    let handle = tokio::spawn(async move {
+        let _ = run_with_listener(listener, room, vote, metrics).await;
+    });
+
+    wait_for_server(addr).await;
+    (addr, handle)
+}
+
+/// TCP connect 재시도로 서버 준비 대기
+async fn wait_for_server(addr: SocketAddr) {
+    for _ in 0..50 {
+        if TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("서버가 시작되지 않음: {addr}");
+}
+
+/// 경량 봇: 메시지 전송 및 자신의 메시지 수신 카운트 반환
+async fn run_bot(id: usize, addr: SocketAddr, msg_count: usize) -> u64 {
+    let stream = TcpStream::connect(addr)
+        .await
+        .unwrap_or_else(|e| panic!("봇 {id} 연결 실패: {e}"));
+
+    let (reader, writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+    let mut writer = BufWriter::new(writer);
+
+    let target = format!("bot_{id}_msg_");
+    let msg_count_u64 = msg_count as u64;
+
+    // 수신 task: 자신의 메시지 패턴과 일치하는 수신 메시지 카운트
+    let recv_target = target.clone();
+    let recv_task = tokio::spawn(async move {
+        let mut count = 0u64;
+        // 타임아웃: 충분한 시간 (180초)
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(180);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, lines.next_line()).await {
+                Ok(Ok(Some(line))) => {
+                    if line.contains(&recv_target) {
+                        count += 1;
+                        if count >= msg_count_u64 {
+                            break;
+                        }
+                    }
+                }
+                // 연결 종료 또는 에러
+                Ok(Ok(None)) | Ok(Err(_)) => break,
+                // 타임아웃
+                Err(_) => break,
+            }
+        }
+        count
+    });
+
+    // 송신: 모든 메시지를 빠르게 전송
+    for seq in 0..msg_count {
+        let msg = format!(
+            r#"{{"type":"chat","text":"bot_{id}_msg_{seq}","client_ts":{ts}}}"#,
+            ts = now_ms()
+        );
+        writer.write_all(msg.as_bytes()).await.unwrap();
+        writer.write_all(b"\n").await.unwrap();
+    }
+    writer.flush().await.unwrap();
+
+    recv_task.await.unwrap_or(0)
+}
+
+/// 공통 테스트 로직: 서버 기동 → 봇 실행 → 누락 assert → 서버 정리
+async fn stress_test(bot_count: usize, msg_per_bot: usize) {
+    let (addr, server_handle) = spawn_server().await;
+    let recv_counter = Arc::new(AtomicU64::new(0));
+    let mut handles = Vec::with_capacity(bot_count);
+
+    // 봇을 배치로 spawn하여 동시 연결 폭주 방지
+    let batch_size = 50;
+    for batch_start in (0..bot_count).step_by(batch_size) {
+        let batch_end = (batch_start + batch_size).min(bot_count);
+        for i in batch_start..batch_end {
+            let counter = recv_counter.clone();
+            handles.push(tokio::spawn(async move {
+                let received = run_bot(i, addr, msg_per_bot).await;
+                counter.fetch_add(received, Ordering::Relaxed);
+            }));
+        }
+        // 배치 간 딜레이: 연결 안정화
+        if batch_end < bot_count {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let expected = (bot_count * msg_per_bot) as u64;
+    let received = recv_counter.load(Ordering::SeqCst);
+    assert_eq!(
+        expected, received,
+        "메시지 누락! expected={expected} received={received} (bot_count={bot_count}, msg_per_bot={msg_per_bot})"
+    );
+
+    server_handle.abort();
+}
+
+// ── 시나리오별 테스트 케이스 ────────────────────────────────────────
+
+#[tokio::test]
+async fn stress_100() {
+    stress_test(100, 10).await;
+}
+
+#[tokio::test]
+async fn stress_300() {
+    stress_test(300, 10).await;
+}
+
+#[tokio::test]
+async fn stress_500() {
+    stress_test(500, 10).await;
+}


### PR DESCRIPTION
## PR: bot&test — 봇 시스템 개선 및 통합 테스트 

### #9 [Bug] recv_task 타임아웃 없음 — 메시지 손실 시 무한 대기
- `BOT_RECV_TIMEOUT_SECS = 30` 상수 추가 (`bot/mod.rs`)
- `normal::run`의 recv_task에 `tokio::time::timeout` 적용
- 타임아웃 발생 시 현재까지 수신된 count 반환 + `warn!` 경고 로그 출력
- `Arc<AtomicU64>` 패턴으로 타임아웃 시에도 count 접근 가능

### #10 [Feature] mixed 봇 모드 추가 — 여러 타입 봇 혼합 실행
- `BotType` 열거형 추가 (Normal, Fickle, Spammer, Ghost, Quitter)
- `RatioSpec` 구조체 + `parse()` / `Display` 구현 (기본값: normal:40,spammer:20,fickle:20,ghost:10,quitter:10)
- `allocate(total, spec)` 배분 함수 (floor 배분 + 나머지 비율순 배분)
- `--mode mixed` 분기 추가, `--ratio` CLI 인자 추가
- 기존 단일 모드 동작 변경 없음

### #11 [Feature] 봇 시나리오 종료 후 결과 리포트 출력
- `RttCounter` 구조체 (AtomicU64 기반 lock-free RTT 누적)
- `ScenarioReport` 구조체 + `Display` 구현 (mode, total_bots, success, failure, elapsed, avg_rtt, vote_integrity)
- `normal::run`, `spammer::run`에 RTT 측정 추가 (송신 시각 Vec 저장 → 수신 시 seq 추출하여 RTT 계산)
- `run_scenario`에서 `Instant::now()` 시작 시각 기록, 성공/실패 집계, 종료 시 summary 출력
- `FickleResult` 구조체 (last_vote, last_snapshot)
- `VoteIntegrityResult` 구조체 (passed, expected, actual, fickle_count)
- `tally_votes()`, `check_vote_integrity()` 순수 함수
- `fickle::run` 변경: 수신 루프 추가, VoteSnapshot 저장, `FickleResult` 반환
- ScenarioReport에 `vote_integrity: PASS/FAIL/N/A` 항목 추가
- fickle/mixed 모드에서 투표 정합성 자동 검증

### #12 [Feature] tests/stress_test.rs 추가 — 통합 부하 테스트
- `server::run_with_listener` 추출 (기존 `run`은 래퍼로 유지)
- `src/lib.rs` 생성하여 라이브러리 크레이트 분리 (통합 테스트에서 내부 모듈 접근 가능)
- `Room::new_with_capacity(65536)` 메서드 추가 (테스트용 대용량 채널)
- 100명 / 300명 / 500명 시나리오 각각 누락률 0% assert
- 배치별 봇 spawn + 180초 타임아웃으로 안정적 실행



### 테스트
- `cargo test -- --test-threads=1`로 전체 실행
- 단위 테스트 + proptest 속성 기반 테스트 47개+
- 통합 부하 테스트 3개 (100/300/500명)